### PR TITLE
Add Coverage Support for pom.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ dist: trusty
 
 script:
   - mvn package --fail-at-end
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  range: 65..95
+  round: down
+  precision: 2
+  status:
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        base: auto
+    project:
+      default:
+        target: 70%
+        threshold: 5%
+        base: auto
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null

--- a/org.planqk.atlas.core/pom.xml
+++ b/org.planqk.atlas.core/pom.xml
@@ -1,27 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	
-	<parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
         <groupId>org.planqk</groupId>
         <artifactId>atlas</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
-	
-	<artifactId>org.planqk.atlas.core</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-annotations</artifactId>
-			<version>2.10.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-commons</artifactId>
-			<version>2.2.5.RELEASE</version>
-			<scope>compile</scope>
-		</dependency>
-	</dependencies>
+    <artifactId>org.planqk.atlas.core</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.10.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
+            <version>2.2.5.RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/org.planqk.atlas.web/pom.xml
+++ b/org.planqk.atlas.web/pom.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
+    <parent>
         <groupId>org.planqk</groupId>
         <artifactId>atlas</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-	<artifactId>org.planqk.atlas.web</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<packaging>war</packaging>
+    <artifactId>org.planqk.atlas.web</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<version>3.13.2</version>
-			<scope>compile</scope>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.planqk</groupId>
-			<artifactId>org.planqk.atlas.core</artifactId>
-			<version>${project.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-annotations</artifactId>
-			<version>2.0.0</version>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.13.2</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.planqk</groupId>
+            <artifactId>org.planqk.atlas.core</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>2.0.0</version>
+        </dependency>
     </dependencies>
 
-	<build>
-		<finalName>${artifactId}</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<mainClass>org.planqk.atlas.web.Application</mainClass>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <finalName>${artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>org.planqk.atlas.web.Application</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,42 @@
 
     <properties>
         <java.version>11</java.version>
+        <jacoco.reportPath>${project.basedir}/../target/jacoco.exec</jacoco.reportPath>
     </properties>
 
     <modules>
         <module>org.planqk.atlas.core</module>
         <module>org.planqk.atlas.web</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <id>agent-for-ut</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <append>true</append>
+                            <destFile>${jacoco.reportPath}</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION

#### Short Description
Add Coverage support for Maven to the whole Project

#### Proposed Changes
- Add Jacoco plugin to Maven
   - Autmaticcaly generated HTML reports and the report mandatory for codecov when running `mvn package`
- Adds configuration for codecov
- Adds codecov to travis.yml
