### PR TITLE
Add main method to Application class

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/Application.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/Application.java
@@ -21,6 +21,7 @@ package org.planqk.atlas.web;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
@@ -44,5 +45,15 @@ public class Application extends SpringBootServletInitializer {
                 "ATLAS IS READY TO USE!\n" +
                 "===================================================";
         LOG.info(readyMessage);
+    }
+
+    /**
+     * Launch the embedded Tomcat server.
+     *
+     * See `application.properties` for its configuration.
+     * @param args
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
     }
 }

--- a/org.planqk.atlas.web/src/main/resources/application.properties
+++ b/org.planqk.atlas.web/src/main/resources/application.properties
@@ -10,3 +10,6 @@ springdoc.swagger-ui.path=/swagger-ui
 springdoc.swagger-ui.config-url=/atlas/v3/api-docs/
 spring.datasource.initialization-mode=always
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
+
+# Embedded Tomcat
+server.servlet.contextPath=/atlas


### PR DESCRIPTION
This adds a `main`-method to the `Application` class so that developers can use Spring Boot's embedded Tomcat server instead of having to set one up.

Also, set the correct context-path for the embedded tomcat server.
