### PR TITLE
Add API versioning on controller-level

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SpringOverrides.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SpringOverrides.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web;
+
+import org.planqk.atlas.web.annotation.VersionedRequestHandlerMapping;
+
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * Class containing overrides for Spring Boot beans
+ */
+@Configuration
+public class SpringOverrides {
+    @Bean
+    public WebMvcRegistrations webMvcRegistrationsHandlerMapping() {
+        return new WebMvcRegistrations() {
+            @Override
+            public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
+                return new VersionedRequestHandlerMapping();
+            }
+        };
+    }
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/ApiVersion.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/ApiVersion.java
@@ -1,0 +1,17 @@
+package org.planqk.atlas.web.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Add API versioning information to a controller or controller method.
+ *
+ * The specified version(s) are appended to the controller's base path (i.e. before the individual route paths).
+ */
+@Target( {ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiVersion {
+    String[] value();
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMapping.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMapping.java
@@ -1,0 +1,55 @@
+package org.planqk.atlas.web.annotation;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
+import org.springframework.web.servlet.mvc.condition.RequestCondition;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * Special implementation of RequestMappingHandlerMapping that optionally adds version suffixes to
+ * controller URLs.
+ */
+public class VersionedRequestHandlerMapping extends RequestMappingHandlerMapping {
+    @Override
+    protected RequestMappingInfo getMappingForMethod(Method method, Class<?> handlerType) {
+        RequestMappingInfo info = createRequestMappingInfo(method);
+        if (info != null) {
+            ApiVersion methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, ApiVersion.class);
+            if (methodAnnotation != null) {
+                // Prepend our version mapping to the real method mapping.
+                info = createApiVersionInfo(methodAnnotation).combine(info);
+            }
+
+            RequestMappingInfo typeInfo = createRequestMappingInfo(handlerType);
+            if (typeInfo != null) {
+                ApiVersion typeAnnotation = AnnotatedElementUtils.findMergedAnnotation(handlerType, ApiVersion.class);
+                if (methodAnnotation == null && typeAnnotation != null) {
+                    // Append our version mapping to the real controller mapping.
+                    typeInfo = typeInfo.combine(createApiVersionInfo(typeAnnotation));
+                }
+                info = typeInfo.combine(info);
+            }
+        }
+        return info;
+    }
+
+    @Nullable
+    private RequestMappingInfo createRequestMappingInfo(AnnotatedElement element) {
+        RequestMapping requestMapping = AnnotatedElementUtils.findMergedAnnotation(element, RequestMapping.class);
+        RequestCondition<?> condition = (element instanceof Class ?
+                getCustomTypeCondition((Class<?>) element) : getCustomMethodCondition((Method) element));
+        return (requestMapping != null ? createRequestMappingInfo(requestMapping, condition) : null);
+    }
+
+    private RequestMappingInfo createApiVersionInfo(ApiVersion annotation) {
+        return new RequestMappingInfo(new PatternsRequestCondition(annotation.value(), getUrlPathHelper(), getPathMatcher(),
+                useSuffixPatternMatch(), useTrailingSlashMatch(), getFileExtensions()),
+                null, null, null, null, null, null);
+    }
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
@@ -28,6 +28,7 @@ import org.planqk.atlas.core.model.Algorithm;
 import org.planqk.atlas.core.model.Tag;
 import org.planqk.atlas.core.services.AlgorithmService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.AlgorithmDto;
 import org.planqk.atlas.web.dtos.AlgorithmListDto;
 import org.planqk.atlas.web.dtos.TagListDto;
@@ -60,6 +61,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.ALGORITHMS)
+@ApiVersion("v1")
 public class AlgorithmController {
 
     final private static Logger LOG = LoggerFactory.getLogger(AlgorithmController.class);

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationController.java
@@ -28,6 +28,7 @@ import org.planqk.atlas.core.model.Implementation;
 import org.planqk.atlas.core.services.AlgorithmService;
 import org.planqk.atlas.core.services.ImplementationService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.ImplementationDto;
 import org.planqk.atlas.web.dtos.ImplementationListDto;
 import org.planqk.atlas.web.dtos.TagListDto;
@@ -61,6 +62,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.IMPLEMENTATIONS)
+@ApiVersion("v1")
 public class ImplementationController {
 
     final private static Logger LOG = LoggerFactory.getLogger(ImplementationController.class);

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationController.java
@@ -47,6 +47,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.planqk.atlas.web.Constants.ALGORITHM_LINK;
@@ -59,7 +60,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @io.swagger.v3.oas.annotations.tags.Tag(name = "implementation")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.ALGORITHMS + "/{algoId}/" + Constants.IMPLEMENTATIONS)
+@RequestMapping("/" + Constants.IMPLEMENTATIONS)
 public class ImplementationController {
 
     final private static Logger LOG = LoggerFactory.getLogger(ImplementationController.class);
@@ -82,15 +83,15 @@ public class ImplementationController {
     public static ImplementationDto createImplementationDto(Implementation implementation) {
         UUID algoId = implementation.getImplementedAlgorithm().getId();
         ImplementationDto dto = ImplementationDto.Converter.convert(implementation);
-        dto.add(linkTo(methodOn(ImplementationController.class).getImplementation(algoId, implementation.getId())).withSelfRel());
+        dto.add(linkTo(methodOn(ImplementationController.class).getImplementation(implementation.getId())).withSelfRel());
         dto.add(linkTo(methodOn(AlgorithmController.class).getAlgorithm(algoId)).withRel(Constants.ALGORITHM_LINK));
-        dto.add(linkTo(methodOn(ImplementationController.class).getTags(algoId, implementation.getId())).withRel(Constants.TAGS));
+        dto.add(linkTo(methodOn(ImplementationController.class).getTags(implementation.getId())).withRel(Constants.TAGS));
         return dto;
     }
 
     @Operation()
     @GetMapping("/")
-    public HttpEntity<ImplementationListDto> getImplementations(@PathVariable UUID algoId) {
+    public HttpEntity<ImplementationListDto> getImplementations(@RequestParam UUID algoId) {
         LOG.debug("Get to retrieve all implementations received.");
         ImplementationListDto dtoList = new ImplementationListDto();
 
@@ -98,7 +99,7 @@ public class ImplementationController {
         for (Implementation impl : implementationService.findAll(RestUtils.getAllPageable())) {
             if (impl.getImplementedAlgorithm().getId().equals(algoId)) {
                 dtoList.add(createImplementationDto(impl));
-                dtoList.add(linkTo(methodOn(ImplementationController.class).getImplementation(algoId, impl.getId()))
+                dtoList.add(linkTo(methodOn(ImplementationController.class).getImplementation(impl.getId()))
                         .withRel(impl.getId().toString()));
             }
         }
@@ -114,7 +115,7 @@ public class ImplementationController {
             @ApiResponse(responseCode = "404", content = @Content)
     })
     @GetMapping("/{implId}")
-    public HttpEntity<ImplementationDto> getImplementation(@PathVariable UUID algoId, @PathVariable UUID implId) {
+    public HttpEntity<ImplementationDto> getImplementation(@PathVariable UUID implId) {
         LOG.debug("Get to retrieve implementation with id: {}.", implId);
 
         Optional<Implementation> implementationOptional = implementationService.findById(implId);
@@ -131,7 +132,7 @@ public class ImplementationController {
             @ApiResponse(responseCode = "400", content = @Content)
     })
     @PostMapping("/")
-    public HttpEntity<ImplementationDto> createImplementation(@PathVariable UUID algoId, @RequestBody ImplementationDto impl) {
+    public HttpEntity<ImplementationDto> createImplementation(@RequestParam UUID algoId, @RequestBody ImplementationDto impl) {
         LOG.debug("Post to create new implementation received.");
 
         Optional<Algorithm> algorithmOptional = algorithmService.findById(algoId);
@@ -157,14 +158,14 @@ public class ImplementationController {
             @ApiResponse(responseCode = "404", content = @Content)
     })
     @GetMapping("/{implId}/" + Constants.TAGS)
-    public HttpEntity<TagListDto> getTags(@PathVariable UUID algoId, @PathVariable UUID implId) {
+    public HttpEntity<TagListDto> getTags(@PathVariable UUID implId) {
         Optional<Implementation> implementationOptional = implementationService.findById(implId);
         if (!implementationOptional.isPresent()) {
             LOG.error("Unable to find implementation with id {} from the repository.", implId);
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
         TagListDto tagListDto = TagController.createTagDtoList(implementationOptional.get().getTags().stream());
-        tagListDto.add(linkTo(methodOn(ImplementationController.class).getTags(algoId, implId)).withSelfRel());
+        tagListDto.add(linkTo(methodOn(ImplementationController.class).getTags(implId)).withSelfRel());
         return new ResponseEntity<>(tagListDto, HttpStatus.OK);
     }
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ProviderController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ProviderController.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.ProviderDto;
 import org.planqk.atlas.web.dtos.ProviderListDto;
 import org.planqk.atlas.core.services.ProviderService;
@@ -50,6 +51,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.PROVIDERS)
+@ApiVersion("v1")
 public class ProviderController {
 
     final private static Logger LOG = LoggerFactory.getLogger(ProviderController.class);

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/QpuController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/QpuController.java
@@ -28,6 +28,7 @@ import org.planqk.atlas.core.model.Qpu;
 import org.planqk.atlas.core.services.ProviderService;
 import org.planqk.atlas.core.services.QpuService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.QpuDto;
 import org.planqk.atlas.web.dtos.QpuListDto;
 import org.planqk.atlas.web.utils.RestUtils;
@@ -59,6 +60,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.QPUS)
+@ApiVersion("v1")
 public class QpuController {
 
     private final static Logger LOG = LoggerFactory.getLogger(QpuController.class);

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/QpuController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/QpuController.java
@@ -58,7 +58,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @io.swagger.v3.oas.annotations.tags.Tag(name = "qpu")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.PROVIDERS + "/{providerId}/" + Constants.QPUS)
+@RequestMapping("/" + Constants.QPUS)
 public class QpuController {
 
     private final static Logger LOG = LoggerFactory.getLogger(QpuController.class);
@@ -71,7 +71,8 @@ public class QpuController {
     }
 
     @GetMapping("/")
-    public HttpEntity<QpuListDto> getQpus(@PathVariable UUID providerId, @RequestParam(required = false) Integer page,
+    public HttpEntity<QpuListDto> getQpus(@RequestParam UUID providerId,
+                                          @RequestParam(required = false) Integer page,
                                           @RequestParam(required = false) Integer size) {
         LOG.debug("Get to retrieve all QPUs received.");
         QpuListDto qpuListDto = new QpuListDto();
@@ -79,8 +80,8 @@ public class QpuController {
         // add all available algorithms to the response
         for (Qpu qpu : qpuService.findAll(RestUtils.getAllPageable())) {
             if (qpu.getProvider().getId().equals(providerId)) {
-                qpuListDto.add(createQpuDto(providerId, qpu));
-                qpuListDto.add(linkTo(methodOn(QpuController.class).getQpu(providerId, qpu.getId())).withRel(qpu.getId().toString()));
+                qpuListDto.add(createQpuDto(qpu));
+                qpuListDto.add(linkTo(methodOn(QpuController.class).getQpu(qpu.getId())).withRel(qpu.getId().toString()));
             }
         }
 
@@ -93,7 +94,7 @@ public class QpuController {
             @ApiResponse(responseCode = "404", content = @Content)
     })
     @GetMapping("/{qpuId}")
-    public HttpEntity<QpuDto> getQpu(@PathVariable UUID providerId, @PathVariable UUID qpuId) {
+    public HttpEntity<QpuDto> getQpu(@PathVariable UUID qpuId) {
         LOG.debug("Get to retrieve QPU with id: {}.", qpuId);
 
         Optional<Qpu> qpuOptional = qpuService.findById(qpuId);
@@ -102,7 +103,7 @@ public class QpuController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
 
-        return new ResponseEntity<>(createQpuDto(providerId, qpuOptional.get()), HttpStatus.OK);
+        return new ResponseEntity<>(createQpuDto(qpuOptional.get()), HttpStatus.OK);
     }
 
     @Operation(responses = {
@@ -111,7 +112,7 @@ public class QpuController {
             @ApiResponse(responseCode = "404", content = @Content)
     })
     @PostMapping("/")
-    public HttpEntity<QpuDto> createQpu(@PathVariable UUID providerId, @RequestBody QpuDto qpuRequest) {
+    public HttpEntity<QpuDto> createQpu(@RequestParam UUID providerId, @RequestBody QpuDto qpuRequest) {
         LOG.debug("Post to create new QPU received.");
 
         Optional<Provider> providerOptional = providerService.findById(providerId);
@@ -128,20 +129,19 @@ public class QpuController {
 
         // store and return QPU
         Qpu qpu = qpuService.save(QpuDto.Converter.convert(qpuRequest, providerOptional.get()));
-        return new ResponseEntity<>(createQpuDto(providerId, qpu), HttpStatus.OK);
+        return new ResponseEntity<>(createQpuDto(qpu), HttpStatus.OK);
     }
 
     /**
      * Create a DTO object for a given {@link Qpu}.
      *
-     * @param providerId the Id of the provider the QPU belongs to
      * @param qpu        the {@link Qpu} to create the DTO for
      * @return the created DTO
      */
-    private QpuDto createQpuDto(UUID providerId, Qpu qpu) {
+    private QpuDto createQpuDto(Qpu qpu) {
         QpuDto qpuDto = QpuDto.Converter.convert(qpu);
-        qpuDto.add(linkTo(methodOn(QpuController.class).getQpu(providerId, qpu.getId())).withSelfRel());
-        qpuDto.add(linkTo(methodOn(ProviderController.class).getProvider(providerId)).withRel(Constants.PROVIDER));
+        qpuDto.add(linkTo(methodOn(QpuController.class).getQpu(qpu.getId())).withSelfRel());
+        qpuDto.add(linkTo(methodOn(ProviderController.class).getProvider(qpu.getProvider().getId())).withRel(Constants.PROVIDER));
         return qpuDto;
     }
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/TagController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/TagController.java
@@ -31,6 +31,7 @@ import org.planqk.atlas.core.model.Implementation;
 import org.planqk.atlas.core.model.Tag;
 import org.planqk.atlas.core.services.TagService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.AlgorithmDto;
 import org.planqk.atlas.web.dtos.AlgorithmListDto;
 import org.planqk.atlas.web.dtos.ImplementationListDto;
@@ -59,6 +60,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.TAGS)
+@ApiVersion("v1")
 public class TagController {
 
     private TagService tagService;

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMappingTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMappingTest.java
@@ -1,0 +1,46 @@
+package org.planqk.atlas.web.annotation;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.junit.Assert.assertEquals;
+
+class VersionedRequestHandlerMappingTest {
+
+    @RequestMapping("/unversioned")
+    static class Unversioned {
+        @RequestMapping("/versioned")
+        @ApiVersion("v1")
+        public void versioned() {
+        }
+    }
+
+    @RequestMapping("/versioned")
+    @ApiVersion("v1")
+    static class Versioned {
+        @RequestMapping("/unversioned")
+        public void unversioned() {
+        }
+
+        @RequestMapping("/versioned")
+        @ApiVersion( {"v1", "v2"})
+        public void versioned() {
+        }
+    }
+
+    private VersionedRequestHandlerMapping mapping = new VersionedRequestHandlerMapping();
+
+    @Test
+    void getMappingForMethod() throws NoSuchMethodException {
+        assertEquals(Set.of("/unversioned/v1/versioned"), getMethodPathMapping(Unversioned.class, "versioned"));
+        assertEquals(Set.of("/versioned/v1/unversioned"), getMethodPathMapping(Versioned.class, "unversioned"));
+        assertEquals(Set.of("/versioned/v1/versioned", "/versioned/v2/versioned"),
+                getMethodPathMapping(Versioned.class, "versioned"));
+    }
+
+    private Set<String> getMethodPathMapping(Class<?> clazz, String methodName) throws NoSuchMethodException {
+        return mapping.getMappingForMethod(clazz.getMethod(methodName), clazz).getPatternsCondition().getPatterns();
+    }
+}


### PR DESCRIPTION
This PR adds API versioning on the controller level. Versions are appended to the controller's path prefix.

This however means that controllers with nested namespaces are not supported. The two affected controllers had their paths changed.

**Fixes**: PlanQK/q-tal#8
