### PR TITLE
Change default PostgreSQL user and database name

### DIFF
--- a/org.planqk.atlas.web/src/main/resources/application.properties
+++ b/org.planqk.atlas.web/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.datasource.driverClassName=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
-spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.url=jdbc:postgresql://localhost:5432/planqk
+spring.datasource.username=planqk
+spring.datasource.password=planqk
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
These properties are only relevant for non-docker setups, in which case
you'd want more descriptive db / user names.

**Fixes**: PlanQK/q-tal#21
