### PR TITLE
Fix OpenAPI schema constraints for EntityModel<T> wrappers

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SpringOverrides.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SpringOverrides.java
@@ -19,7 +19,9 @@
 package org.planqk.atlas.web;
 
 import org.planqk.atlas.web.annotation.VersionedRequestHandlerMapping;
+import org.planqk.atlas.web.utils.EntityModelConverter;
 
+import io.swagger.v3.core.converter.ModelConverters;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +32,10 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  */
 @Configuration
 public class SpringOverrides {
+    public SpringOverrides() {
+        ModelConverters.getInstance().addConverter(new EntityModelConverter());
+    }
+
     @Bean
     public WebMvcRegistrations webMvcRegistrationsHandlerMapping() {
         return new WebMvcRegistrations() {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/EntityModelConverter.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/EntityModelConverter.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.utils;
+
+import java.util.Iterator;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.media.Schema;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Links;
+
+/**
+ * Custom converter for EntityModel classes.
+ *
+ * Spring HATEOAS' EntityModel class is special because it uses Jackson's @JsonWrapped to "copy" the actual DTO's
+ * properties into the EntityModel instance. Unfortunately, information on whether properties are required or not is
+ * lost in the process. This wrapper aims to fix that by copying the DTO's schema and then manually adding the
+ * EntityModel-specific fields (for now, just _links).
+ */
+public class EntityModelConverter implements ModelConverter {
+    @Override
+    public Schema resolve(AnnotatedType annotatedType, ModelConverterContext context, Iterator<ModelConverter> chain) {
+        final JavaType type;
+        if (annotatedType.getType() instanceof JavaType) {
+            type = (JavaType) annotatedType.getType();
+        } else {
+            type = Json.mapper().constructType(annotatedType.getType());
+        }
+        if (type != null && annotatedType.isResolveAsRef()) {
+            final var cls = type.getRawClass();
+            if (EntityModel.class.isAssignableFrom(cls)) {
+                return resolveEntityModel(type, context);
+            }
+        }
+        if (chain.hasNext()) {
+            return chain.next().resolve(annotatedType, context, chain);
+        } else {
+            return null;
+        }
+    }
+
+    private Schema resolveEntityModel(JavaType type, ModelConverterContext context) {
+        final var entityType = type.getBindings().getBoundType(0);
+        final Schema resolved = context.resolve(new AnnotatedType().type(entityType).resolveAsRef(false));
+        if (resolved == null)
+            throw new RuntimeException(String.format("Cannot resolve %s", entityType.getTypeName()));
+
+        try {
+            final Schema wrapper = clone(resolved);
+            wrapper.name(String.format("EntityModel%s", wrapper.getName()));
+            wrapper.addProperties("_links", context.resolve(new AnnotatedType()
+                    .type(Links.class)
+                    .resolveAsRef(true)));
+            return wrapper;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Schema clone(Schema property) throws JsonProcessingException {
+        if (property == null)
+            return null;
+
+        String cloneName = property.getName();
+        property = Json.mapper().readValue(Json.pretty(property), Schema.class);
+        property.setName(cloneName);
+        return property;
+    }
+}

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/utils/EntityModelConverterTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/utils/EntityModelConverterTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.utils;
+
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.hateoas.EntityModel;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityModelConverterTest {
+    @NoArgsConstructor
+    @EqualsAndHashCode
+    @Data
+    private static class SimpleDto {
+        @NotNull
+        private String notNull;
+        private String nullable;
+    }
+
+    @Test
+    void verifySchema() {
+        final var converters = new ModelConverters();
+        converters.addConverter(new EntityModelConverter());
+
+        final var normal = converters.resolveAsResolvedSchema(new AnnotatedType().type(SimpleDto.class).resolveAsRef(false));
+        assertEquals(List.of("notNull"), normal.schema.getRequired());
+
+        final var instance = new EntityModel<>(new SimpleDto());
+        final var wrapped = converters.resolveAsResolvedSchema(new AnnotatedType().type(instance.getClass()).resolveAsRef(false));
+        assertEquals(List.of("notNull"), normal.schema.getRequired());
+    }
+}


### PR DESCRIPTION
The EntityModel class wraps our DTOs, but due to a (maybe deliberate?) choice,
Swagger ignores constraints on @JsonWrapped-imported properties.

This means we lose our required properties, min/max values, and so on, which is unacceptable.

