### PR TITLE
Add 'DirtiesContext' annotation to the base service test

### DIFF
--- a/org.planqk.atlas.core/src/test/java/org/planqk/atlas/core/util/AtlasDatabaseTestBase.java
+++ b/org.planqk.atlas.core/src/test/java/org/planqk/atlas/core/util/AtlasDatabaseTestBase.java
@@ -22,12 +22,14 @@ package org.planqk.atlas.core.util;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = {DatabaseTestEnvironmentConfiguration.class})
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(DatabaseExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public abstract class AtlasDatabaseTestBase {
 
 }


### PR DESCRIPTION

#### Short Description
This annotation is added ensure every test uses an empty database.
