### PR TITLE
Init AlgoDto sets to avoid NullPointer

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
@@ -20,6 +20,7 @@
 package org.planqk.atlas.web.dtos;
 
 import java.util.Set;
+import java.util.HashSet;
 import java.util.UUID;
 
 import org.planqk.atlas.core.model.ComputationModel;
@@ -84,9 +85,9 @@ public class AlgorithmDto {
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Schema(accessMode = WRITE_ONLY)
-    private Set<ProblemTypeDto> problemTypes;
+    private Set<ProblemTypeDto> problemTypes = new HashSet<>();
 
-    private Set<String> applicationAreas;
+    private Set<String> applicationAreas = new HashSet<>();
 
     // we do not embedded tags into the object (via @jsonInclude) - instead, we add
     // a hateoas link to the associated tags
@@ -94,6 +95,6 @@ public class AlgorithmDto {
     // annotate this for swagger as well, because swagger doesn't recognize the json
     // property annotation
     @Schema(accessMode = WRITE_ONLY)
-    private Set<TagDto> tags;
+    private Set<TagDto> tags = new HashSet<>();
 
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
@@ -1,5 +1,6 @@
 package org.planqk.atlas.web.dtos;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.validation.constraints.NotNull;
@@ -24,7 +25,7 @@ public class QuantumAlgorithmDto extends AlgorithmDto {
     @NotNull(message = "QuantumComputationModel must not be null!")
     private QuantumComputationModel quantumComputationModel;
 
-    private Set<QuantumResource> requiredQuantumResources;
+    private Set<QuantumResource> requiredQuantumResources = new HashSet<>();
     private String speedUp;
 
 }


### PR DESCRIPTION
#### Short Description
Last PR introduced possiblity for NullPointerExceptions since we removed the Null-Check-Getter methods in Algorithm because all Sets are initialized but we forgot to do the same in the AlgorithmDTO. This leads to the ModelMapper mapping Null-Sets to our Algorithm which are not checked anymore.

**Fixes**: 
- Sets in AlgorithmDTO are initialized