### PR TITLE
Use a custom LinkBuilder for HATEOAS links

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMapping.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMapping.java
@@ -16,6 +16,15 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * version suffixes to controller URLs.
  */
 public class VersionedRequestHandlerMapping extends RequestMappingHandlerMapping {
+    /**
+     * Utility function to manually add routes from a given handler instance.
+     *
+     * Only for testing!
+     */
+    public void populateFromHandler(Object handler) {
+        detectHandlerMethods(handler);
+    }
+
     @Override
     protected RequestMappingInfo getMappingForMethod(Method method, Class<?> handlerType) {
         RequestMappingInfo info = createRequestMappingInfo(method);

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/AlgoRelationTypeAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/AlgoRelationTypeAssembler.java
@@ -1,31 +1,29 @@
 package org.planqk.atlas.web.linkassembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import java.util.UUID;
 
 import org.planqk.atlas.web.controller.AlgoRelationTypeController;
 import org.planqk.atlas.web.dtos.AlgoRelationTypeDto;
+
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
 public class AlgoRelationTypeAssembler extends GenericLinkAssembler<AlgoRelationTypeDto> {
 
     @Override
     public void addLinks(EntityModel<AlgoRelationTypeDto> resource) {
-        resource.add(linkTo(methodOn(AlgoRelationTypeController.class).getAlgoRelationTypeById(getId(resource)))
+        resource.add(links.linkTo(methodOn(AlgoRelationTypeController.class).getAlgoRelationTypeById(getId(resource)))
                 .withSelfRel());
-        resource.add(linkTo(methodOn(AlgoRelationTypeController.class).updateAlgoRelationType(getId(resource),
+        resource.add(links.linkTo(methodOn(AlgoRelationTypeController.class).updateAlgoRelationType(getId(resource),
                 getContent(resource))).withRel("update"));
-        resource.add(linkTo(methodOn(AlgoRelationTypeController.class).deleteAlgoRelationType(getId(resource)))
+        resource.add(links.linkTo(methodOn(AlgoRelationTypeController.class).deleteAlgoRelationType(getId(resource)))
                 .withRel("delete"));
-
     }
 
     private UUID getId(EntityModel<AlgoRelationTypeDto> resource) {
         return resource.getContent().getId();
     }
-
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/AlgorithmAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/AlgorithmAssembler.java
@@ -1,8 +1,5 @@
 package org.planqk.atlas.web.linkassembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import java.util.UUID;
 
 import org.planqk.atlas.web.Constants;
@@ -19,50 +16,52 @@ import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 @Component
 public class AlgorithmAssembler extends GenericLinkAssembler<AlgorithmDto> {
 
     @Override
     public void addLinks(EntityModel<AlgorithmDto> resource) {
-        resource.add(linkTo(methodOn(AlgorithmController.class).getAlgorithm(getId(resource))).withSelfRel());
-        resource.add(linkTo(methodOn(AlgorithmController.class).updateAlgorithm(getId(resource), getContent(resource)))
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getAlgorithm(getId(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).updateAlgorithm(getId(resource), getContent(resource)))
                 .withRel("update"));
-        resource.add(linkTo(methodOn(AlgorithmController.class).deleteAlgorithm(getId(resource))).withRel("delete"));
-        resource.add(linkTo(methodOn(AlgorithmController.class).getTags(getId(resource))).withRel(Constants.TAGS));
-        resource.add(linkTo(methodOn(ImplementationController.class).getImplementations(getId(resource)))
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).deleteAlgorithm(getId(resource))).withRel("delete"));
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getTags(getId(resource))).withRel(Constants.TAGS));
+        resource.add(links.linkTo(methodOn(ImplementationController.class).getImplementations(getId(resource)))
                 .withRel(Constants.IMPLEMENTATIONS));
-        resource.add(linkTo(methodOn(AlgorithmController.class).getProblemTypes(getId(resource)))
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getProblemTypes(getId(resource)))
                 .withRel(Constants.PROBLEM_TYPES));
-        resource.add(linkTo(methodOn(AlgorithmController.class).getAlgorithmRelations(getId(resource)))
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getAlgorithmRelations(getId(resource)))
                 .withRel(Constants.ALGORITHM_RELATIONS));
-        resource.add(linkTo(methodOn(AlgorithmController.class).getPublications(getId(resource)))
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getPublications(getId(resource)))
                 .withRel(Constants.PUBLICATIONS));
-        resource.add(linkTo(methodOn(AlgorithmController.class).getPatternRelations(getId(resource)))
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getPatternRelations(getId(resource)))
                 .withRel(Constants.PATTERN_RELATIONS));
     }
 
     public void addProblemTypeLink(CollectionModel<EntityModel<ProblemTypeDto>> resources, UUID id) {
-        resources.add(linkTo(methodOn(AlgorithmController.class).getProblemTypes(id)).withSelfRel());
+        resources.add(links.linkTo(methodOn(AlgorithmController.class).getProblemTypes(id)).withSelfRel());
     }
 
     public void addTagLink(CollectionModel<EntityModel<TagDto>> resources, UUID id) {
-        resources.add(linkTo(methodOn(AlgorithmController.class).getTags(id)).withSelfRel());
+        resources.add(links.linkTo(methodOn(AlgorithmController.class).getTags(id)).withSelfRel());
     }
 
     public void addPublicationLink(CollectionModel<EntityModel<PublicationDto>> resources, UUID id) {
-        resources.add(linkTo(methodOn(AlgorithmController.class).getPublications(id)).withSelfRel());
+        resources.add(links.linkTo(methodOn(AlgorithmController.class).getPublications(id)).withSelfRel());
     }
 
     public void addAlgorithmRelationLink(CollectionModel<EntityModel<AlgorithmRelationDto>> resultCollection,
                                          UUID sourceAlgorithm_id) {
         resultCollection.add(
-                linkTo(methodOn(AlgorithmController.class).getAlgorithmRelations(sourceAlgorithm_id)).withSelfRel());
+                links.linkTo(methodOn(AlgorithmController.class).getAlgorithmRelations(sourceAlgorithm_id)).withSelfRel());
     }
 
     public void addPatternRelationLink(CollectionModel<EntityModel<PatternRelationDto>> resultCollection, UUID
             id) {
         resultCollection.add(
-                linkTo(methodOn(AlgorithmController.class).getPatternRelations(id)).withSelfRel());
+                links.linkTo(methodOn(AlgorithmController.class).getPatternRelations(id)).withSelfRel());
     }
 
     private UUID getId(EntityModel<AlgorithmDto> resource) {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/AlgorithmRelationAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/AlgorithmRelationAssembler.java
@@ -1,28 +1,28 @@
 package org.planqk.atlas.web.linkassembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import java.util.UUID;
 
 import org.planqk.atlas.web.controller.AlgoRelationTypeController;
 import org.planqk.atlas.web.controller.AlgorithmController;
 import org.planqk.atlas.web.dtos.AlgorithmRelationDto;
+
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
 public class AlgorithmRelationAssembler extends GenericLinkAssembler<AlgorithmRelationDto> {
 
     @Override
     public void addLinks(EntityModel<AlgorithmRelationDto> resource) {
-        resource.add(linkTo(methodOn(AlgorithmController.class).getAlgorithm(getSourceAlgorithmId(resource)))
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getAlgorithm(getSourceAlgorithmId(resource)))
                 .withRel("sourceAlgorithm"));
-        resource.add(linkTo(methodOn(AlgorithmController.class).getAlgorithm(getTargetAlgorithmId(resource)))
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getAlgorithm(getTargetAlgorithmId(resource)))
                 .withRel("targetAlgorithm"));
-        resource.add(linkTo(
+        resource.add(links.linkTo(
                 methodOn(AlgoRelationTypeController.class).getAlgoRelationTypeById(getAlgoRelationTypeId(resource)))
-                        .withRel("algoRelationType"));
+                .withRel("algoRelationType"));
     }
 
     private UUID getSourceAlgorithmId(EntityModel<AlgorithmRelationDto> resource) {
@@ -36,5 +36,4 @@ public class AlgorithmRelationAssembler extends GenericLinkAssembler<AlgorithmRe
     private UUID getAlgoRelationTypeId(EntityModel<AlgorithmRelationDto> resource) {
         return resource.getContent().getAlgoRelationType().getId();
     }
-
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/BackendAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/BackendAssembler.java
@@ -2,23 +2,23 @@ package org.planqk.atlas.web.linkassembler;
 
 import java.util.UUID;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.planqk.atlas.web.controller.BackendController;
 import org.planqk.atlas.web.dtos.BackendDto;
+
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
 public class BackendAssembler extends GenericLinkAssembler<BackendDto> {
 
     @Override
     public void addLinks(EntityModel<BackendDto> resource) {
-        resource.add(linkTo(methodOn(BackendController.class).getBackend(getId(resource))).withSelfRel());
-        resource.add(linkTo(methodOn(BackendController.class).updateBackend(getId(resource), resource.getContent())).withSelfRel());
-        resource.add(linkTo(methodOn(BackendController.class).createBackend(resource.getContent())).withSelfRel());
-        resource.add(linkTo(methodOn(BackendController.class).deleteBackend(getId(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(BackendController.class).getBackend(getId(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(BackendController.class).updateBackend(getId(resource), resource.getContent())).withSelfRel());
+        resource.add(links.linkTo(methodOn(BackendController.class).createBackend(resource.getContent())).withSelfRel());
+        resource.add(links.linkTo(methodOn(BackendController.class).deleteBackend(getId(resource))).withSelfRel());
     }
 
     private UUID getId(EntityModel<BackendDto> resource) {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/CloudServiceAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/CloudServiceAssembler.java
@@ -1,36 +1,26 @@
 package org.planqk.atlas.web.linkassembler;
 
-import org.planqk.atlas.web.controller.CloudServiceController;
-import org.planqk.atlas.web.dtos.CloudServiceDto;
-import org.springframework.hateoas.CollectionModel;
-import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.server.SimpleRepresentationModelAssembler;
-import org.springframework.stereotype.Component;
-
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.UUID;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import org.planqk.atlas.web.controller.CloudServiceController;
+import org.planqk.atlas.web.dtos.CloudServiceDto;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.stereotype.Component;
+
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
-public class CloudServiceAssembler implements SimpleRepresentationModelAssembler<CloudServiceDto> {
+public class CloudServiceAssembler extends GenericLinkAssembler<CloudServiceDto> {
 
     @Override
     public void addLinks(EntityModel<CloudServiceDto> resource) {
-        resource.add(linkTo(methodOn(CloudServiceController.class).getCloudService(getId(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(CloudServiceController.class).getCloudService(getId(resource))).withSelfRel());
 
         resource.add(
-                linkTo(methodOn(CloudServiceController.class).deleteCloudService(getId(resource))).withRel("delete"));
-    }
-
-    @Override
-    public void addLinks(CollectionModel<EntityModel<CloudServiceDto>> resources) {
-        Iterator<EntityModel<CloudServiceDto>> iter = resources.getContent().iterator();
-        while (iter.hasNext()) {
-            addLinks(iter.next());
-        }
+                links.linkTo(methodOn(CloudServiceController.class).deleteCloudService(getId(resource))).withRel("delete"));
     }
 
     public void addLinks(Collection<EntityModel<CloudServiceDto>> content) {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/DiscussionCommentAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/DiscussionCommentAssembler.java
@@ -27,7 +27,6 @@ import org.planqk.atlas.web.dtos.DiscussionCommentDto;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
@@ -35,9 +34,9 @@ public class DiscussionCommentAssembler extends GenericLinkAssembler<DiscussionC
 
     @Override
     public void addLinks(EntityModel<DiscussionCommentDto> resource) {
-        resource.add(linkTo(methodOn(DiscussionCommentController.class).getDiscussionComment(this.getID(resource))).withSelfRel());
-        resource.add(linkTo(methodOn(DiscussionCommentController.class).deleteDiscussionComment(this.getID(resource))).withRel("delete"));
-        resource.add(linkTo(methodOn(DiscussionCommentController.class).updateDiscussionComment(this.getID(resource), getContent(resource))).withRel("update"));
+        resource.add(links.linkTo(methodOn(DiscussionCommentController.class).getDiscussionComment(this.getID(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(DiscussionCommentController.class).deleteDiscussionComment(this.getID(resource))).withRel("delete"));
+        resource.add(links.linkTo(methodOn(DiscussionCommentController.class).updateDiscussionComment(this.getID(resource), getContent(resource))).withRel("update"));
     }
 
     private UUID getID(EntityModel<DiscussionCommentDto> resource) {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/DiscussionTopicAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/DiscussionTopicAssembler.java
@@ -30,7 +30,6 @@ import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
@@ -38,10 +37,10 @@ public class DiscussionTopicAssembler extends GenericLinkAssembler<DiscussionTop
 
     @Override
     public void addLinks(EntityModel<DiscussionTopicDto> resource) {
-        resource.add(linkTo(methodOn(DiscussionTopicController.class).getDiscussionTopic(this.getID(resource))).withSelfRel());
-        resource.add(linkTo(methodOn(DiscussionTopicController.class).deleteDiscussionTopic(this.getID(resource))).withRel("delete"));
-        resource.add(linkTo(methodOn(DiscussionTopicController.class).updateDiscussionTopic(this.getID(resource), getContent(resource))).withRel("update"));
-        resource.add(linkTo(methodOn(DiscussionTopicController.class).getDiscussionCommentsOfTopic(this.getID(resource))).withRel(Constants.DISCUSSION_COMMENTS));
+        resource.add(links.linkTo(methodOn(DiscussionTopicController.class).getDiscussionTopic(this.getID(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(DiscussionTopicController.class).deleteDiscussionTopic(this.getID(resource))).withRel("delete"));
+        resource.add(links.linkTo(methodOn(DiscussionTopicController.class).updateDiscussionTopic(this.getID(resource), getContent(resource))).withRel("update"));
+        resource.add(links.linkTo(methodOn(DiscussionTopicController.class).getDiscussionCommentsOfTopic(this.getID(resource))).withRel(Constants.DISCUSSION_COMMENTS));
     }
 
     private UUID getID(EntityModel<DiscussionTopicDto> resource) {
@@ -49,6 +48,6 @@ public class DiscussionTopicAssembler extends GenericLinkAssembler<DiscussionTop
     }
 
     public void addDiscussionCommentLink(CollectionModel<EntityModel<DiscussionCommentDto>> results, UUID id) {
-        results.add(linkTo(methodOn(DiscussionTopicController.class).getDiscussionCommentsOfTopic(id)).withSelfRel());
+        results.add(links.linkTo(methodOn(DiscussionTopicController.class).getDiscussionCommentsOfTopic(id)).withSelfRel());
     }
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/GenericLinkAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/GenericLinkAssembler.java
@@ -3,10 +3,13 @@ package org.planqk.atlas.web.linkassembler;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 
 public abstract class GenericLinkAssembler<T> {
+    @Autowired
+    protected LinkBuilderService links;
 
     public abstract void addLinks(EntityModel<T> resource);
 
@@ -24,5 +27,4 @@ public abstract class GenericLinkAssembler<T> {
     public T getContent(EntityModel<T> resource) {
         return resource.getContent();
     }
-
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/GenericLinkAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/GenericLinkAssembler.java
@@ -1,7 +1,6 @@
 package org.planqk.atlas.web.linkassembler;
 
 import java.util.Collection;
-import java.util.Iterator;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.CollectionModel;
@@ -14,14 +13,13 @@ public abstract class GenericLinkAssembler<T> {
     public abstract void addLinks(EntityModel<T> resource);
 
     public void addLinks(CollectionModel<EntityModel<T>> resources) {
-        Iterator<EntityModel<T>> iter = resources.getContent().iterator();
-        while (iter.hasNext()) {
-            addLinks(iter.next());
+        for (EntityModel<T> entity : resources.getContent()) {
+            addLinks(entity);
         }
     }
 
     public void addLinks(Collection<EntityModel<T>> content) {
-        addLinks(new CollectionModel<EntityModel<T>>(content));
+        addLinks(new CollectionModel<>(content));
     }
 
     public T getContent(EntityModel<T> resource) {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/ImplementationAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/ImplementationAssembler.java
@@ -1,8 +1,5 @@
 package org.planqk.atlas.web.linkassembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import java.util.UUID;
 
 import org.planqk.atlas.web.Constants;
@@ -10,9 +7,12 @@ import org.planqk.atlas.web.controller.AlgorithmController;
 import org.planqk.atlas.web.controller.ImplementationController;
 import org.planqk.atlas.web.dtos.ImplementationDto;
 import org.planqk.atlas.web.dtos.TagDto;
+
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
 public class ImplementationAssembler extends GenericLinkAssembler<ImplementationDto> {
@@ -20,17 +20,16 @@ public class ImplementationAssembler extends GenericLinkAssembler<Implementation
     @Override
     public void addLinks(EntityModel<ImplementationDto> resource) {
         resource.add(
-                linkTo(methodOn(ImplementationController.class).getImplementation(getId(resource)))
+                links.linkTo(methodOn(ImplementationController.class).getImplementation(getId(resource)))
                         .withSelfRel());
-        resource.add(linkTo(methodOn(AlgorithmController.class).getAlgorithm(getAlgId(resource)))
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getAlgorithm(getAlgId(resource)))
                 .withRel(Constants.ALGORITHM_LINK));
-        resource.add(linkTo(methodOn(ImplementationController.class).getTags(getId(resource)))
+        resource.add(links.linkTo(methodOn(ImplementationController.class).getTags(getId(resource)))
                 .withRel(Constants.TAGS));
-
     }
 
     public void addTagLink(CollectionModel<EntityModel<TagDto>> resultCollection, UUID implId) {
-        resultCollection.add(linkTo(methodOn(ImplementationController.class).getTags(implId)).withSelfRel());
+        resultCollection.add(links.linkTo(methodOn(ImplementationController.class).getTags(implId)).withSelfRel());
     }
 
     public UUID getId(EntityModel<ImplementationDto> resource) {
@@ -40,5 +39,4 @@ public class ImplementationAssembler extends GenericLinkAssembler<Implementation
     public UUID getAlgId(EntityModel<ImplementationDto> resource) {
         return resource.getContent().getImplementedAlgorithm().getId();
     }
-
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/LinkBuilder.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/LinkBuilder.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.linkassembler;
+
+import java.util.List;
+
+import org.springframework.hateoas.Affordance;
+import org.springframework.hateoas.TemplateVariables;
+import org.springframework.hateoas.server.core.TemplateVariableAwareLinkBuilderSupport;
+import org.springframework.web.util.UriComponents;
+
+/**
+ * Helper class that mimics {@link org.springframework.hateoas.server.mvc.WebMvcLinkBuilder}
+ *
+ * Needed to retain WebMvcLinkBuilder's flexibility and interface.
+ */
+public class LinkBuilder extends TemplateVariableAwareLinkBuilderSupport<LinkBuilder> {
+    LinkBuilder(UriComponents components) {
+        super(components, TemplateVariables.NONE, List.of());
+    }
+
+    private LinkBuilder(UriComponents components, TemplateVariables variables, List<Affordance> affordances) {
+        super(components, variables, affordances);
+    }
+
+    @Override
+    protected LinkBuilder getThis() {
+        return this;
+    }
+
+    @Override
+    protected LinkBuilder createNewInstance(UriComponents components, List<Affordance> affordances, TemplateVariables variables) {
+        return new LinkBuilder(components, variables, affordances);
+    }
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/LinkBuilderService.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/LinkBuilderService.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.linkassembler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.core.annotation.SynthesizingMethodParameter;
+import org.springframework.hateoas.server.core.DummyInvocationUtils;
+import org.springframework.hateoas.server.core.LastInvocationAware;
+import org.springframework.hateoas.server.core.MethodInvocation;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.method.annotation.RequestParamMethodArgumentResolver;
+import org.springframework.web.method.support.CompositeUriComponentsContributor;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
+import org.springframework.web.servlet.mvc.method.annotation.PathVariableMethodArgumentResolver;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Custom HATEOAS link builder that resolves paths using the container's {@link RequestMappingInfoHandlerMapping}
+ * instance.
+ */
+@Component
+@RequiredArgsConstructor
+public class LinkBuilderService {
+    private static final CompositeUriComponentsContributor contributor;
+    private static final ParameterNameDiscoverer parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
+
+    private final RequestMappingHandlerMapping mappings;
+
+    static {
+        contributor = new CompositeUriComponentsContributor(
+                new PathVariableMethodArgumentResolver(), new RequestParamMethodArgumentResolver(false));
+    }
+
+    /**
+     * Special version of {@link WebMvcLinkBuilder#linkTo(Object)} that resolves paths via {@link
+     * RequestMappingInfoHandlerMapping}.
+     */
+    public LinkBuilder linkTo(Object invocationValue) {
+        Assert.isInstanceOf(LastInvocationAware.class, invocationValue);
+
+        var invocations = DummyInvocationUtils.getLastInvocationAware(invocationValue);
+        if (invocations == null) {
+            throw new IllegalStateException(String.format("Could not obtain previous invocation from %s!", invocationValue));
+        }
+
+        var invocation = invocations.getLastInvocation();
+        Assert.notNull(invocation, "No invocation present");
+
+        var mappingInfo = resolveInvocation(invocation);
+        if (mappingInfo == null) {
+            // In case there's no mapping, using just the annotations is our only option!
+            return new LinkBuilder(WebMvcLinkBuilder.linkTo(invocationValue).toUriComponentsBuilder().build());
+        }
+
+        UriComponentsBuilder builder;
+        // This is required for tests, which don't necessarily have a current request
+        // (for example, when using this method to build an URL in order to perform a request).
+        // If we supply a null builder in such a case, fromMethodCall will throw an InvalidStateException,
+        // as it cannot figure out the base URL to use!
+        if (RequestContextHolder.getRequestAttributes() != null)
+            builder = ServletUriComponentsBuilder.fromCurrentServletMapping();
+        else
+            builder = UriComponentsBuilder.newInstance();
+        return new LinkBuilder(appendMappingParameters(appendMappingPath(builder, mappingInfo), invocation).build());
+    }
+
+    private RequestMappingInfo resolveInvocation(MethodInvocation invocation) {
+        for (var entry : this.mappings.getHandlerMethods().entrySet()) {
+            if (entry.getValue().getMethod().equals(invocation.getMethod()))
+                return entry.getKey();
+        }
+        return null;
+    }
+
+    private UriComponentsBuilder appendMappingPath(UriComponentsBuilder builder, RequestMappingInfo mapping) {
+        var patternSet = mapping.getPatternsCondition().getPatterns();
+        Assert.notEmpty(patternSet, "Need at least one URL mapping");
+        builder.path(patternSet.stream().sorted().findFirst().orElse(""));
+        return builder;
+    }
+
+    private UriComponentsBuilder appendMappingParameters(UriComponentsBuilder builder, MethodInvocation invocation) {
+        int paramCount = invocation.getMethod().getParameterCount();
+        int argCount = invocation.getArguments().length;
+        if (paramCount != argCount) {
+            throw new IllegalArgumentException("Number of method parameters " + paramCount +
+                    " does not match number of argument values " + argCount);
+        }
+
+        final Map<String, Object> uriVars = new HashMap<>();
+        for (int i = 0; i < paramCount; i++) {
+            MethodParameter param = new SynthesizingMethodParameter(invocation.getMethod(), i);
+            param.initParameterNameDiscovery(parameterNameDiscoverer);
+            contributor.contributeMethodArgument(param, invocation.getArguments()[i], builder, uriVars);
+        }
+
+        // This may not be all the URI variables, supply what we have so far..
+        return builder.uriVariables(uriVars);
+    }
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/PatternRelationAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/PatternRelationAssembler.java
@@ -1,8 +1,5 @@
 package org.planqk.atlas.web.linkassembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import java.util.UUID;
 
 import org.planqk.atlas.web.Constants;
@@ -14,16 +11,18 @@ import org.planqk.atlas.web.dtos.PatternRelationDto;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 @Component
 public class PatternRelationAssembler extends GenericLinkAssembler<PatternRelationDto> {
 
     @Override
     public void addLinks(EntityModel<PatternRelationDto> resource) {
         resource.add(
-                linkTo(methodOn(PatternRelationController.class).getPatternRelation(getId(resource))).withSelfRel());
-        resource.add(linkTo(methodOn(AlgorithmController.class).getAlgorithm(getAlgorithmId(resource)))
+                links.linkTo(methodOn(PatternRelationController.class).getPatternRelation(getId(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(AlgorithmController.class).getAlgorithm(getAlgorithmId(resource)))
                 .withRel(Constants.ALGORITHM));
-        resource.add(linkTo(methodOn(PatternRelationTypeController.class).getPatternRelationType(getTypeId(resource)))
+        resource.add(links.linkTo(methodOn(PatternRelationTypeController.class).getPatternRelationType(getTypeId(resource)))
                 .withRel(Constants.PATTERN_RELATION_TYPES));
     }
 

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/PatternRelationTypeAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/PatternRelationTypeAssembler.java
@@ -1,8 +1,5 @@
 package org.planqk.atlas.web.linkassembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import java.util.UUID;
 
 import org.planqk.atlas.web.controller.PatternRelationTypeController;
@@ -11,16 +8,18 @@ import org.planqk.atlas.web.dtos.PatternRelationTypeDto;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 @Component
 public class PatternRelationTypeAssembler extends GenericLinkAssembler<PatternRelationTypeDto> {
 
     @Override
     public void addLinks(EntityModel<PatternRelationTypeDto> resource) {
-        resource.add(linkTo(methodOn(PatternRelationTypeController.class).getPatternRelationType(getId(resource)))
+        resource.add(links.linkTo(methodOn(PatternRelationTypeController.class).getPatternRelationType(getId(resource)))
                 .withSelfRel());
-        resource.add(linkTo(methodOn(PatternRelationTypeController.class).updatePatternRelationType(getId(resource),
+        resource.add(links.linkTo(methodOn(PatternRelationTypeController.class).updatePatternRelationType(getId(resource),
                 getContent(resource))).withRel("update"));
-        resource.add(linkTo(methodOn(PatternRelationTypeController.class).deletePatternRelationType(getId(resource)))
+        resource.add(links.linkTo(methodOn(PatternRelationTypeController.class).deletePatternRelationType(getId(resource)))
                 .withRel("delete"));
     }
 

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/ProblemTypeAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/ProblemTypeAssembler.java
@@ -1,30 +1,29 @@
 package org.planqk.atlas.web.linkassembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import java.util.UUID;
 
 import org.planqk.atlas.web.controller.ProblemTypeController;
 import org.planqk.atlas.web.dtos.ProblemTypeDto;
+
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
 public class ProblemTypeAssembler extends GenericLinkAssembler<ProblemTypeDto> {
 
     @Override
     public void addLinks(EntityModel<ProblemTypeDto> resource) {
-        resource.add(linkTo(methodOn(ProblemTypeController.class).getProblemTypeById(getId(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(ProblemTypeController.class).getProblemTypeById(getId(resource))).withSelfRel());
         resource.add(
-                linkTo(methodOn(ProblemTypeController.class).updateProblemType(getId(resource), getContent(resource)))
+                links.linkTo(methodOn(ProblemTypeController.class).updateProblemType(getId(resource), getContent(resource)))
                         .withRel("update"));
         resource.add(
-                linkTo(methodOn(ProblemTypeController.class).deleteProblemType(getId(resource))).withRel("delete"));
+                links.linkTo(methodOn(ProblemTypeController.class).deleteProblemType(getId(resource))).withRel("delete"));
     }
 
     private UUID getId(EntityModel<ProblemTypeDto> resource) {
         return resource.getContent().getId();
     }
-
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/PublicationAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/PublicationAssembler.java
@@ -18,36 +18,35 @@
  *******************************************************************************/
 package org.planqk.atlas.web.linkassembler;
 
+import java.util.UUID;
+
 import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.PublicationController;
 import org.planqk.atlas.web.dtos.AlgorithmDto;
 import org.planqk.atlas.web.dtos.PublicationDto;
+
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
-
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
 public class PublicationAssembler extends GenericLinkAssembler<PublicationDto> {
 
     @Override
-    public void addLinks(EntityModel<PublicationDto> resource){
-            resource.add(linkTo(methodOn(PublicationController.class).getPublication(this.getId(resource))).withSelfRel());
-            resource.add(linkTo(methodOn(PublicationController.class).updatePublication(this.getId(resource), this.getContent(resource))).withRel("update"));
-            resource.add(linkTo(methodOn(PublicationController.class).deletePublication(this.getId(resource))).withRel("delete"));
-            resource.add(linkTo(methodOn(PublicationController.class).getAlgorithms(this.getId(resource))).withRel(Constants.ALGORITHMS));
+    public void addLinks(EntityModel<PublicationDto> resource) {
+        resource.add(links.linkTo(methodOn(PublicationController.class).getPublication(this.getId(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(PublicationController.class).updatePublication(this.getId(resource), this.getContent(resource))).withRel("update"));
+        resource.add(links.linkTo(methodOn(PublicationController.class).deletePublication(this.getId(resource))).withRel("delete"));
+        resource.add(links.linkTo(methodOn(PublicationController.class).getAlgorithms(this.getId(resource))).withRel(Constants.ALGORITHMS));
     }
 
-    private UUID getId(EntityModel<PublicationDto> resource){
+    private UUID getId(EntityModel<PublicationDto> resource) {
         return resource.getContent().getId();
     }
 
-    public void addAlgorithmLink(CollectionModel<EntityModel<AlgorithmDto>> ressources, UUID id){
-        ressources.add(linkTo(methodOn(PublicationController.class).getAlgorithms(id)).withSelfRel());
+    public void addAlgorithmLink(CollectionModel<EntityModel<AlgorithmDto>> ressources, UUID id) {
+        ressources.add(links.linkTo(methodOn(PublicationController.class).getAlgorithms(id)).withSelfRel());
     }
-
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/QuantumResourceAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/QuantumResourceAssembler.java
@@ -26,7 +26,6 @@ import org.planqk.atlas.web.dtos.QuantumResourceDto;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @SuppressWarnings("ConstantConditions")
@@ -34,13 +33,13 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 public class QuantumResourceAssembler extends GenericLinkAssembler<QuantumResourceDto> {
     @Override
     public void addLinks(EntityModel<QuantumResourceDto> resource) {
-        resource.add(linkTo(methodOn(QuantumResourceController.class)
+        resource.add(links.linkTo(methodOn(QuantumResourceController.class)
                 .deleteQuantumResource(resource.getContent().getId()))
                 .withRel("delete"));
-        resource.add(linkTo(methodOn(QuantumResourceController.class)
+        resource.add(links.linkTo(methodOn(QuantumResourceController.class)
                 .getQuantumResource(resource.getContent().getId()))
                 .withSelfRel());
-        resource.add(linkTo(methodOn(QuantumResourceTypeController.class)
+        resource.add(links.linkTo(methodOn(QuantumResourceTypeController.class)
                 .getQuantumResourceType(resource.getContent().getType().getId()))
                 .withRel("type"));
         // TODO (Maybe) add link to the entities linked to this quantum Resource, e.g. the Quantum Algorithms

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/QuantumResourceTypeAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/QuantumResourceTypeAssembler.java
@@ -25,7 +25,6 @@ import org.planqk.atlas.web.dtos.QuantumResourceTypeDto;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @SuppressWarnings("ConstantConditions")
@@ -33,13 +32,13 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 public class QuantumResourceTypeAssembler extends GenericLinkAssembler<QuantumResourceTypeDto> {
     @Override
     public void addLinks(EntityModel<QuantumResourceTypeDto> resource) {
-        resource.add(linkTo(methodOn(QuantumResourceTypeController.class)
+        resource.add(links.linkTo(methodOn(QuantumResourceTypeController.class)
                 .getQuantumResourceType(resource.getContent().getId()))
                 .withSelfRel());
-        resource.add(linkTo(methodOn(QuantumResourceTypeController.class)
+        resource.add(links.linkTo(methodOn(QuantumResourceTypeController.class)
                 .getResourceTypes(1, 50))
                 .withRel("all-types"));
-        resource.add(linkTo(methodOn(QuantumResourceTypeController.class)
+        resource.add(links.linkTo(methodOn(QuantumResourceTypeController.class)
                 .deleteQuantumResourceType(resource.getContent().getId()))
                 .withRel("delete"));
     }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/SoftwarePlatformAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/SoftwarePlatformAssembler.java
@@ -1,37 +1,27 @@
 package org.planqk.atlas.web.linkassembler;
 
-import org.planqk.atlas.web.controller.SoftwarePlatformController;
-import org.planqk.atlas.web.dtos.SoftwarePlatformDto;
-import org.springframework.hateoas.CollectionModel;
-import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.server.SimpleRepresentationModelAssembler;
-import org.springframework.stereotype.Component;
-
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.UUID;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import org.planqk.atlas.web.controller.SoftwarePlatformController;
+import org.planqk.atlas.web.dtos.SoftwarePlatformDto;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.stereotype.Component;
+
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
-public class SoftwarePlatformAssembler implements SimpleRepresentationModelAssembler<SoftwarePlatformDto> {
+public class SoftwarePlatformAssembler extends GenericLinkAssembler<SoftwarePlatformDto> {
 
     @Override
     public void addLinks(EntityModel<SoftwarePlatformDto> resource) {
         resource.add(
-                linkTo(methodOn(SoftwarePlatformController.class).getSoftwarePlatform(getId(resource))).withSelfRel());
+                links.linkTo(methodOn(SoftwarePlatformController.class).getSoftwarePlatform(getId(resource))).withSelfRel());
 
-        resource.add(linkTo(methodOn(SoftwarePlatformController.class).deleteSoftwarePlatform(getId(resource)))
+        resource.add(links.linkTo(methodOn(SoftwarePlatformController.class).deleteSoftwarePlatform(getId(resource)))
                 .withRel("delete"));
-    }
-
-    @Override
-    public void addLinks(CollectionModel<EntityModel<SoftwarePlatformDto>> resources) {
-        Iterator<EntityModel<SoftwarePlatformDto>> iter = resources.getContent().iterator();
-        while (iter.hasNext()) {
-            addLinks(iter.next());
-        }
     }
 
     public void addLinks(Collection<EntityModel<SoftwarePlatformDto>> content) {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/TagAssembler.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/linkassembler/TagAssembler.java
@@ -1,8 +1,5 @@
 package org.planqk.atlas.web.linkassembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import java.util.UUID;
 
 import org.planqk.atlas.web.Constants;
@@ -10,32 +7,34 @@ import org.planqk.atlas.web.controller.TagController;
 import org.planqk.atlas.web.dtos.AlgorithmDto;
 import org.planqk.atlas.web.dtos.ImplementationDto;
 import org.planqk.atlas.web.dtos.TagDto;
+
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
 public class TagAssembler extends GenericLinkAssembler<TagDto> {
 
     @Override
     public void addLinks(EntityModel<TagDto> resource) {
-        resource.add(linkTo(methodOn(TagController.class).getTagById(getId(resource))).withSelfRel());
-        resource.add(linkTo(methodOn(TagController.class).getAlgorithmsOfTag(getId(resource)))
+        resource.add(links.linkTo(methodOn(TagController.class).getTagById(getId(resource))).withSelfRel());
+        resource.add(links.linkTo(methodOn(TagController.class).getAlgorithmsOfTag(getId(resource)))
                 .withRel(Constants.ALGORITHMS));
-        resource.add(linkTo(methodOn(TagController.class).getImplementationsOfTag(getId(resource)))
+        resource.add(links.linkTo(methodOn(TagController.class).getImplementationsOfTag(getId(resource)))
                 .withRel(Constants.IMPLEMENTATIONS));
     }
 
     public void addAlgorithmLink(CollectionModel<EntityModel<AlgorithmDto>> resources, UUID id) {
-        resources.add(linkTo(methodOn(TagController.class).getAlgorithmsOfTag(id)).withSelfRel());
+        resources.add(links.linkTo(methodOn(TagController.class).getAlgorithmsOfTag(id)).withSelfRel());
     }
 
     public void addImplementationLink(CollectionModel<EntityModel<ImplementationDto>> resources, UUID id) {
-        resources.add(linkTo(methodOn(TagController.class).getImplementationsOfTag(id)).withSelfRel());
+        resources.add(links.linkTo(methodOn(TagController.class).getImplementationsOfTag(id)).withSelfRel());
     }
 
     private UUID getId(EntityModel<TagDto> resource) {
         return resource.getContent().getId();
     }
-
 }

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmControllerTest.java
@@ -47,13 +47,7 @@ import org.planqk.atlas.web.dtos.AlgorithmRelationDto;
 import org.planqk.atlas.web.dtos.PatternRelationDto;
 import org.planqk.atlas.web.dtos.QuantumResourceDto;
 import org.planqk.atlas.web.dtos.QuantumResourceTypeDto;
-import org.planqk.atlas.web.linkassembler.AlgorithmAssembler;
-import org.planqk.atlas.web.linkassembler.AlgorithmRelationAssembler;
-import org.planqk.atlas.web.linkassembler.PatternRelationAssembler;
-import org.planqk.atlas.web.linkassembler.ProblemTypeAssembler;
-import org.planqk.atlas.web.linkassembler.PublicationAssembler;
-import org.planqk.atlas.web.linkassembler.QuantumResourceAssembler;
-import org.planqk.atlas.web.linkassembler.TagAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -65,9 +59,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -93,45 +85,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AlgorithmController.class)
 @ExtendWith(MockitoExtension.class)
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class AlgorithmControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-        @Bean
-        public PublicationAssembler publicationAssembler() {
-            return new PublicationAssembler();
-        }
-
-        @Bean
-        public ProblemTypeAssembler problemTypeAssembler() {
-            return new ProblemTypeAssembler();
-        }
-
-        @Bean
-        public TagAssembler tagAssembler() {
-            return new TagAssembler();
-        }
-
-        @Bean
-        public PatternRelationAssembler patternRelationAssembler() {
-            return new PatternRelationAssembler();
-        }
-
-        @Bean
-        public AlgorithmAssembler algorithmAssembler() {
-            return new AlgorithmAssembler();
-        }
-
-        @Bean
-        public AlgorithmRelationAssembler algorithmRelationAssembler() {
-            return new AlgorithmRelationAssembler();
-        }
-
-        @Bean
-        public QuantumResourceAssembler quantumResourceAssembler() {
-            return new QuantumResourceAssembler();
-        }
-    }
 
     @MockBean
     private AlgorithmService algorithmService;

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/CloudServiceControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/CloudServiceControllerTest.java
@@ -12,19 +12,16 @@ import org.planqk.atlas.core.model.CloudService;
 import org.planqk.atlas.core.services.CloudServiceService;
 import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.dtos.CloudServiceDto;
-import org.planqk.atlas.web.linkassembler.CloudServiceAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.MediaType;
@@ -45,21 +42,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = { CloudServiceController.class })
 @ExtendWith({ MockitoExtension.class })
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class CloudServiceControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-        @Bean
-        public CloudServiceAssembler getCloudServiceAssembler() {
-            return new CloudServiceAssembler();
-        }
-
-        @Bean
-        public PagedResourcesAssembler<CloudServiceDto> getPagedResourcesAssembler() {
-            return new PagedResourcesAssembler<>(null, null);
-        }
-    }
-
     @MockBean
     private CloudServiceService cloudServiceService;
 

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
@@ -32,7 +32,7 @@ import org.planqk.atlas.core.services.DiscussionCommentService;
 import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.DiscussionCommentDto;
-import org.planqk.atlas.web.linkassembler.DiscussionCommentAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 import org.planqk.atlas.web.utils.HateoasUtils;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 
@@ -46,9 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -63,25 +61,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = {DiscussionCommentController.class})
 @ExtendWith( {MockitoExtension.class})
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class DiscussionCommentControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-        @Bean
-        public DiscussionCommentAssembler getDiscussionCommentAssembler() {
-            return new DiscussionCommentAssembler();
-        }
-    }
-
     @MockBean
     private PagedResourcesAssembler<DiscussionCommentDto> paginationAssembler;
 

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionTopicControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionTopicControllerTest.java
@@ -31,8 +31,7 @@ import org.planqk.atlas.core.services.DiscussionTopicService;
 import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.DiscussionTopicDto;
-import org.planqk.atlas.web.linkassembler.DiscussionCommentAssembler;
-import org.planqk.atlas.web.linkassembler.DiscussionTopicAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 import org.planqk.atlas.web.utils.HateoasUtils;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 
@@ -47,9 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -73,26 +70,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = {DiscussionTopicController.class})
 @ExtendWith( {MockitoExtension.class})
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class DiscussionTopicControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-        @Bean
-        public DiscussionTopicAssembler getDiscussionTopicAssembler() {
-            return new DiscussionTopicAssembler();
-        }
-
-        @Bean
-        public DiscussionCommentAssembler getDiscussionCommentAssembler() {
-            return new DiscussionCommentAssembler();
-        }
-
-        @Bean
-        public PagedResourcesAssembler<DiscussionTopicDto> getPagedResourcesAssembler() {
-            return new PagedResourcesAssembler<>(null, null);
-        }
-    }
-
     @MockBean
     private PagedResourcesAssembler<DiscussionTopicDto> paginationAssembler;
     @MockBean

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ImplementationControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ImplementationControllerTest.java
@@ -32,8 +32,8 @@ import org.planqk.atlas.core.services.AlgorithmService;
 import org.planqk.atlas.core.services.ImplementationService;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.ImplementationDto;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 import org.planqk.atlas.web.linkassembler.ImplementationAssembler;
-import org.planqk.atlas.web.linkassembler.TagAssembler;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -47,9 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -75,16 +73,8 @@ import static org.springframework.web.servlet.mvc.method.annotation.MvcUriCompon
 @WebMvcTest(ImplementationController.class)
 @ExtendWith(MockitoExtension.class)
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class ImplementationControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-        @Bean
-        public TagAssembler tagAssembler() {
-            return new TagAssembler();
-        }
-    }
-
     @MockBean
     private AlgorithmService algorithmService;
     @MockBean

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PatternRelationControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PatternRelationControllerTest.java
@@ -33,16 +33,14 @@ import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.AlgorithmDto;
 import org.planqk.atlas.web.dtos.PatternRelationDto;
 import org.planqk.atlas.web.dtos.PatternRelationTypeDto;
-import org.planqk.atlas.web.linkassembler.PatternRelationAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 import org.planqk.atlas.web.utils.HateoasUtils;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -60,16 +58,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @WebMvcTest(PatternRelationController.class)
 @ExtendWith(MockitoExtension.class)
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class PatternRelationControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-        @Bean
-        public PatternRelationAssembler patternRelationAssembler() {
-            return new PatternRelationAssembler();
-        }
-    }
-
     @MockBean
     private PatternRelationService patternRelationService;
     @MockBean

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PatternRelationTypeControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PatternRelationTypeControllerTest.java
@@ -28,16 +28,14 @@ import org.planqk.atlas.core.services.PatternRelationTypeService;
 import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.PatternRelationTypeDto;
-import org.planqk.atlas.web.linkassembler.PatternRelationTypeAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 import org.planqk.atlas.web.utils.HateoasUtils;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -55,16 +53,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @WebMvcTest(PatternRelationTypeController.class)
 @ExtendWith(MockitoExtension.class)
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class PatternRelationTypeControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-        @Bean
-        public PatternRelationTypeAssembler patternRelationTypeAssembler() {
-            return new PatternRelationTypeAssembler();
-        }
-    }
-
     @MockBean
     private PatternRelationTypeService patternRelationTypeService;
     @MockBean

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/QuantumResourceControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/QuantumResourceControllerTest.java
@@ -28,7 +28,7 @@ import org.planqk.atlas.core.model.QuantumResourceType;
 import org.planqk.atlas.core.services.QuantumResourceService;
 import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
-import org.planqk.atlas.web.linkassembler.QuantumResourceAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,9 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -57,17 +55,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(QuantumResourceController.class)
 @ExtendWith(MockitoExtension.class)
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class QuantumResourceControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-
-        @Bean
-        public QuantumResourceAssembler quantumResourceAssembler() {
-            return new QuantumResourceAssembler();
-        }
-    }
-
     @MockBean
     private QuantumResourceService resourceService;
 

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/QuantumResourceTypeControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/QuantumResourceTypeControllerTest.java
@@ -29,7 +29,7 @@ import org.planqk.atlas.core.services.QuantumResourceService;
 import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.QuantumResourceTypeDto;
-import org.planqk.atlas.web.linkassembler.QuantumResourceTypeAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,9 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.test.web.servlet.MockMvc;
@@ -59,17 +57,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(QuantumResourceTypeController.class)
 @ExtendWith(MockitoExtension.class)
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class QuantumResourceTypeControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-
-        @Bean
-        public QuantumResourceTypeAssembler quantumResourceTypeAssembler() {
-            return new QuantumResourceTypeAssembler();
-        }
-    }
-
     @MockBean
     private QuantumResourceService resourceService;
 

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/SoftwarePlatformControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/SoftwarePlatformControllerTest.java
@@ -12,19 +12,16 @@ import org.planqk.atlas.core.model.SoftwarePlatform;
 import org.planqk.atlas.core.services.SoftwarePlatformService;
 import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.dtos.SoftwarePlatformDto;
-import org.planqk.atlas.web.linkassembler.SoftwarePlatformAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.MediaType;
@@ -47,21 +44,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = { SoftwarePlatformController.class })
 @ExtendWith({ MockitoExtension.class })
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class SoftwarePlatformControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-        @Bean
-        public SoftwarePlatformAssembler getSoftwarePlatformAssembler() {
-            return new SoftwarePlatformAssembler();
-        }
-
-        @Bean
-        public PagedResourcesAssembler<SoftwarePlatformDto> getPagedResourcesAssembler() {
-            return new PagedResourcesAssembler<>(null, null);
-        }
-    }
-
     @MockBean
     private SoftwarePlatformService softwarePlatformService;
 

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/TagControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/TagControllerTest.java
@@ -30,8 +30,7 @@ import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.controller.util.TestControllerUtils;
 import org.planqk.atlas.web.dtos.TagDto;
-import org.planqk.atlas.web.linkassembler.AlgorithmAssembler;
-import org.planqk.atlas.web.linkassembler.ImplementationAssembler;
+import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
 import org.planqk.atlas.web.linkassembler.TagAssembler;
 import org.planqk.atlas.web.utils.HateoasUtils;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
@@ -46,9 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -70,21 +67,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(TagController.class)
 @ExtendWith(MockitoExtension.class)
 @AutoConfigureMockMvc
+@EnableLinkAssemblers
 public class TagControllerTest {
-
-    @TestConfiguration
-    public static class TestConfig {
-        @Bean
-        public AlgorithmAssembler algorithmAssembler() {
-            return new AlgorithmAssembler();
-        }
-
-        @Bean
-        public ImplementationAssembler implementationAssembler() {
-            return new ImplementationAssembler();
-        }
-    }
-
     @MockBean
     private TagService tagService;
     @MockBean

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/DummyController.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/DummyController.java
@@ -1,0 +1,18 @@
+package org.planqk.atlas.web.linkassembler;
+
+import org.planqk.atlas.web.annotation.ApiVersion;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/controller")
+@ApiVersion("v1")
+public class DummyController {
+    @GetMapping("/test")
+    public HttpEntity<Void> test() {
+        return null;
+    }
+}

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/DummyController.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/DummyController.java
@@ -1,3 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package org.planqk.atlas.web.linkassembler;
 
 import org.planqk.atlas.web.annotation.ApiVersion;

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/EnableLinkAssemblers.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/EnableLinkAssemblers.java
@@ -1,0 +1,18 @@
+package org.planqk.atlas.web.linkassembler;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.ComponentScan;
+
+@Target( {ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ComponentScan("org.planqk.atlas.web.linkassembler")
+public @interface EnableLinkAssemblers {
+}

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/EnableLinkAssemblers.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/EnableLinkAssemblers.java
@@ -1,3 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package org.planqk.atlas.web.linkassembler;
 
 import java.lang.annotation.Documented;

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/LinkBuilderServiceIntegrationTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/LinkBuilderServiceIntegrationTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.linkassembler;
+
+import org.planqk.atlas.web.SpringOverrides;
+import org.planqk.atlas.web.controller.RootController;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.hateoas.IanaLinkRelations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@WebMvcTest( {RootController.class, DummyController.class})
+@EnableLinkAssemblers
+@Import(SpringOverrides.class)
+public class LinkBuilderServiceIntegrationTest {
+    @Autowired
+    private LinkBuilderService service;
+
+    @Test
+    public void resolvesAsUnversioned() {
+        var link = service.linkTo(methodOn(RootController.class).root()).withSelfRel();
+        assertEquals(IanaLinkRelations.SELF, link.getRel());
+        assertEquals("/", link.getHref());
+    }
+
+    @Test
+    public void resolvesAsVersioned() {
+        var link = service.linkTo(methodOn(DummyController.class).test()).withSelfRel();
+        assertEquals(IanaLinkRelations.SELF, link.getRel());
+        assertEquals("/controller/v1/test", link.getHref());
+    }
+}

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/LinkBuilderServiceTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/LinkBuilderServiceTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.linkassembler;
+
+import org.planqk.atlas.web.annotation.VersionedRequestHandlerMapping;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.hateoas.IanaLinkRelations;
+import org.springframework.http.HttpEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+public class LinkBuilderServiceTest {
+    private VersionedRequestHandlerMapping mappings = new VersionedRequestHandlerMapping();
+    private LinkBuilderService service = new LinkBuilderService(mappings);
+
+    private final Controller c = new Controller();
+
+    @BeforeEach
+    public void setupMappings() {
+        mappings.populateFromHandler(c);
+    }
+
+    @Test
+    public void invalid() {
+        assertEquals("/", service.linkTo(methodOn(NonController.class).test()).withSelfRel().getHref());
+        assertEquals("/test", service.linkTo(methodOn(Controller.class).nonEndpoint()).withSelfRel().getHref());
+    }
+
+    @Test
+    public void simpleMethodCall() {
+        var link = service.linkTo(methodOn(Controller.class).endpoint()).withSelfRel();
+        assertEquals(IanaLinkRelations.SELF, link.getRel());
+        assertEquals("/test/test", link.getHref());
+    }
+
+    @Test
+    public void simpleSlash() {
+        var link = service.linkTo(methodOn(Controller.class).endpoint()).slash("something").withSelfRel();
+        assertEquals(IanaLinkRelations.SELF, link.getRel());
+        assertEquals("/test/test/something", link.getHref());
+    }
+
+    static class NonController {
+        public HttpEntity<Void> test() {
+            return null;
+        }
+    }
+
+    @RequestMapping("/test")
+    static class Controller {
+        @RequestMapping("/test")
+        public HttpEntity<Void> endpoint() {
+            return null;
+        }
+
+        public HttpEntity<Void> nonEndpoint() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Using the standard `WebMvcLinkBuilder` is not possible because it only inspects
the class- and method-level `@RequestMapping` annotations, ignoring any
custom processing that might happen in a `RequestMappingHandlerMapping` subclass.

This also removes the explicit linkassembler.* instantiations in our tests, as
this becomes more cumbersome when having to instantiate their dependencies as well.

**Fixes**: PlanQK/q-tal#35
