### PR TITLE
Improve Swagger spec for polymorphic types

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SwaggerConfiguration.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SwaggerConfiguration.java
@@ -25,12 +25,14 @@ import org.planqk.atlas.web.dtos.ClassicAlgorithmDto;
 import org.planqk.atlas.web.dtos.QuantumAlgorithmDto;
 import org.planqk.atlas.web.utils.EntityModelConverter;
 import org.planqk.atlas.web.utils.LinkRemoverModelConverter;
+import org.planqk.atlas.web.utils.OverrideModelConverter;
 
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Lazy;
 
 /**
@@ -50,10 +52,20 @@ public class SwaggerConfiguration {
 
     @Bean
     @Lazy(false)
+    @DependsOn("linkRemoverModelConverter")
     public EntityModelConverter entityModelConverter() {
-        final var converter = new EntityModelConverter(Map.of(
+        final var converter = new EntityModelConverter();
+        ModelConverters.getInstance().addConverter(converter);
+        return converter;
+    }
+
+    @Bean
+    @Lazy(false)
+    @DependsOn("entityModelConverter")
+    public OverrideModelConverter overrideModelConverter() {
+        final var converter = new OverrideModelConverter(Map.of(
                 AlgorithmDto.class, AlgorithmSchema.class
-                ));
+        ));
         ModelConverters.getInstance().addConverter(converter);
         return converter;
     }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
@@ -41,7 +41,6 @@ import lombok.NoArgsConstructor;
 @JsonSubTypes( {@JsonSubTypes.Type(value = QuantumAlgorithmDto.class, name = "QUANTUM"),
         @JsonSubTypes.Type(value = ClassicAlgorithmDto.class, name = "CLASSIC"),
         @JsonSubTypes.Type(value = QuantumAlgorithmDto.class, name = "HYBRID")})
-@Schema(oneOf = {QuantumAlgorithmDto.class, ClassicAlgorithmDto.class}, description = "either a quantum or a classic algorithm", title = "quantum/classic algorithm")
 public class AlgorithmDto {
     private UUID id;
 

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ClassicAlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ClassicAlgorithmDto.java
@@ -1,7 +1,9 @@
 package org.planqk.atlas.web.dtos;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.planqk.atlas.core.model.ComputationModel;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -11,5 +13,9 @@ import lombok.ToString;
 @Data
 @JsonTypeName("CLASSIC")
 public class ClassicAlgorithmDto extends AlgorithmDto {
-
+    @Override
+    @Schema(type = "string", allowableValues = {"CLASSIC"})
+    public ComputationModel getComputationModel() {
+        return super.getComputationModel();
+    }
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
+import org.planqk.atlas.core.model.ComputationModel;
 import org.planqk.atlas.core.model.QuantumComputationModel;
 import org.planqk.atlas.core.model.QuantumImplementation;
 
@@ -33,4 +34,10 @@ public class QuantumAlgorithmDto extends AlgorithmDto {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Schema(accessMode = WRITE_ONLY)
     private Set<QuantumImplementation> implementations = new HashSet<>();
+
+    @Override
+    @Schema(type = "string", allowableValues = {"QUANTUM"})
+    public ComputationModel getComputationModel() {
+        return super.getComputationModel();
+    }
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/EntityModelConverter.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/EntityModelConverter.java
@@ -18,19 +18,15 @@
  *******************************************************************************/
 package org.planqk.atlas.web.utils;
 
-import java.lang.reflect.Type;
 import java.util.Iterator;
-import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.ResolvedType;
 import com.fasterxml.jackson.databind.JavaType;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.Schema;
-import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Links;
 
@@ -42,10 +38,7 @@ import org.springframework.hateoas.Links;
  * lost in the process. This wrapper aims to fix that by copying the DTO's schema and then manually adding the
  * EntityModel-specific fields (for now, just _links).
  */
-@RequiredArgsConstructor
 public class EntityModelConverter implements ModelConverter {
-    private final Map<Type, Type> contentOverrides;
-
     @Override
     public Schema resolve(AnnotatedType annotatedType, ModelConverterContext context, Iterator<ModelConverter> chain) {
         final JavaType type;
@@ -68,11 +61,10 @@ public class EntityModelConverter implements ModelConverter {
     }
 
     private Schema resolveEntityModel(JavaType type, ModelConverterContext context) {
-        final var boundEntityType = type.getBindings().getBoundType(0);
-        final var actualEntityType = applyOverrides(boundEntityType);
-        final Schema resolved = context.resolve(new AnnotatedType().type(actualEntityType).resolveAsRef(false));
+        final var entityType = type.getBindings().getBoundType(0);
+        final Schema resolved = context.resolve(new AnnotatedType().type(entityType).resolveAsRef(false));
         if (resolved == null)
-            throw new RuntimeException(String.format("Cannot resolve %s", actualEntityType.getTypeName()));
+            throw new RuntimeException(String.format("Cannot resolve %s", entityType.getTypeName()));
 
         try {
             final Schema wrapper = clone(resolved);
@@ -94,20 +86,5 @@ public class EntityModelConverter implements ModelConverter {
         property = Json.mapper().readValue(Json.pretty(property), Schema.class);
         property.setName(cloneName);
         return property;
-    }
-
-    private Type applyOverrides(Type type) {
-        final var clazz = classFromType(type);
-        if (clazz != null)
-            return contentOverrides.getOrDefault(clazz, type);
-        return type;
-    }
-
-    private static Class<?> classFromType(Type type) {
-        if (type instanceof Class<?>)
-            return (Class<?>) type;
-        if (type instanceof ResolvedType)
-            return ((ResolvedType) type).getRawClass();
-        return null;
     }
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/OverrideModelConverter.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/OverrideModelConverter.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.utils;
+
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.ResolvedType;
+import com.fasterxml.jackson.databind.JavaType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.media.Schema;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * ModelConverter that allows overriding {@link Schema} objects for Java classes.
+ */
+@RequiredArgsConstructor
+public class OverrideModelConverter implements ModelConverter {
+    private final Map<Type, Type> contentOverrides;
+
+    @Override
+    public Schema resolve(AnnotatedType annotatedType, ModelConverterContext context, Iterator<ModelConverter> chain) {
+        final JavaType type;
+        if (annotatedType.getType() instanceof JavaType) {
+            type = (JavaType) annotatedType.getType();
+        } else {
+            type = Json.mapper().constructType(annotatedType.getType());
+        }
+        if (type != null) {
+            annotatedType.type(applyOverrides(type));
+        }
+        if (chain.hasNext()) {
+            return chain.next().resolve(annotatedType, context, chain);
+        } else {
+            return null;
+        }
+    }
+
+    private Type applyOverrides(Type type) {
+        final var clazz = classFromType(type);
+        if (clazz != null)
+            return contentOverrides.getOrDefault(clazz, type);
+        return type;
+    }
+
+    private static Class<?> classFromType(Type type) {
+        if (type instanceof Class<?>)
+            return (Class<?>) type;
+        if (type instanceof ResolvedType)
+            return ((ResolvedType) type).getRawClass();
+        return null;
+    }
+}

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/utils/OverrideModelConverterTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/utils/OverrideModelConverterTest.java
@@ -25,15 +25,13 @@ import javax.validation.constraints.NotNull;
 
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverters;
-import io.swagger.v3.core.util.Json;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
-import org.springframework.hateoas.EntityModel;
 
 import static org.junit.Assert.assertEquals;
 
-public class EntityModelConverterTest {
+public class OverrideModelConverterTest {
     @NoArgsConstructor
     @Data
     private static class SimpleDto {
@@ -42,19 +40,21 @@ public class EntityModelConverterTest {
         private String nullable;
     }
 
+    @NoArgsConstructor
+    @Data
+    private static class SimpleDtoOverride {
+        @NotNull
+        private String otherField;
+    }
+
     @Test
-    void verifySchema() {
+    void verifySchemaOverride() {
         final var converters = new ModelConverters();
-        converters.addConverter(new EntityModelConverter());
+        converters.addConverter(new OverrideModelConverter(Map.of(SimpleDto.class, SimpleDtoOverride.class)));
 
-        final var normal = converters.resolveAsResolvedSchema(new AnnotatedType().type(SimpleDto.class).resolveAsRef(false));
-        assertEquals(List.of("notNull"), normal.schema.getRequired());
-        assertEquals(2, normal.schema.getProperties().size());
-
-        final var wrapped = converters.resolveAsResolvedSchema(new AnnotatedType().type(
-                Json.mapper().getTypeFactory().constructParametricType(EntityModel.class, SimpleDto.class))
+        final var wrapped = converters.resolveAsResolvedSchema(new AnnotatedType().type(SimpleDto.class)
                 .resolveAsRef(false));
-        assertEquals(List.of("notNull"), wrapped.schema.getRequired());
-        assertEquals(3, wrapped.schema.getProperties().size());
+        assertEquals(List.of("otherField"), wrapped.schema.getRequired());
+        assertEquals(1, wrapped.schema.getProperties().size());
     }
 }


### PR DESCRIPTION
This allows us to have simple custom schema objects for polymorphic types.

Unfortunately, simply setting `oneOf = ...` on the parent class of one of our
polymorphic DTOs doesn't work, as the resulting type spec contains reference cycles
or mixes property lists with union types (which isn't supported by code generators).

**Fixes**: PlanQK/q-tal#48
