### PR TITLE
Fix Travis to use OpenJDK instead of OracleJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_script:
   # TODO Consider replacing with planqk/initialized-db:latest once that image becomes mandatory
   - docker run --rm -d -p 5432:5432 -e POSTGRES_DB=planqk_test -e POSTGRES_PASSWORD=planqk -e POSTGRES_USER=planqk -d postgres
 script:
-  #- sed -i -e "s&spring.datasource.url=jdbc:postgresql://localhost:5432/planqk&spring.datasource.url=jdbc:postgresql://localhost:5432/planqk_test&" org.planqk.atlas.web/src/main/resources/application.properties
   - mvn package --fail-at-end
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: bionic
 sudo: required
 language: java
 jdk:
-  - oraclejdk11
+  - openjdk11
 services:
   - docker
 
@@ -11,7 +11,7 @@ before_script:
   # TODO Consider replacing with planqk/initialized-db:latest once that image becomes mandatory
   - docker run --rm -d -p 5432:5432 -e POSTGRES_DB=planqk_test -e POSTGRES_PASSWORD=planqk -e POSTGRES_USER=planqk -d postgres
 script:
-  - sed -i -e "s&spring.datasource.url=jdbc:postgresql://localhost:5432/planqk&spring.datasource.url=jdbc:postgresql://localhost:5432/planqk_test&" org.planqk.atlas.web/src/main/resources/application.properties
+  #- sed -i -e "s&spring.datasource.url=jdbc:postgresql://localhost:5432/planqk&spring.datasource.url=jdbc:postgresql://localhost:5432/planqk_test&" org.planqk.atlas.web/src/main/resources/application.properties
   - mvn package --fail-at-end
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
@@ -70,7 +70,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@WebMvcTest(DiscussionCommentController.class)
 @ExtendWith( {MockitoExtension.class})
 @AutoConfigureMockMvc
 @EnableLinkAssemblers

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionTopicControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionTopicControllerTest.java
@@ -45,6 +45,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
@@ -67,7 +68,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@WebMvcTest(DiscussionTopicController.class)
 @ExtendWith( {MockitoExtension.class})
 @AutoConfigureMockMvc
 @EnableLinkAssemblers


### PR DESCRIPTION
#### Short Description
Replaces `oraclejdk11` with `openjdk11` in the travis.yml

