### PR TITLE
Remove Database dependency for Controller Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_script:
   # TODO Consider replacing with planqk/initialized-db:latest once that image becomes mandatory
   - docker run --rm -d -p 5432:5432 -e POSTGRES_DB=planqk_test -e POSTGRES_PASSWORD=planqk -e POSTGRES_USER=planqk -d postgres
 script:
-  - sed -i -e "s&spring.datasource.url=jdbc:postgresql://localhost:5432/planqk&spring.datasource.url=jdbc:postgresql://localhost:5432/planqk_test&" org.planqk.atlas.web/src/main/resources/application.properties
   - mvn package --fail-at-end
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
@@ -45,10 +45,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -70,8 +68,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@ExtendWith( {MockitoExtension.class})
+@WebMvcTest({DiscussionCommentController.class, DiscussionTopicController.class})
+@ExtendWith({MockitoExtension.class})
 @AutoConfigureMockMvc
 @EnableLinkAssemblers
 public class DiscussionCommentControllerTest {

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionTopicControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionTopicControllerTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import org.planqk.atlas.core.model.DiscussionTopic;
 import org.planqk.atlas.core.model.Status;
+import org.planqk.atlas.core.services.DiscussionCommentService;
 import org.planqk.atlas.core.services.DiscussionTopicService;
 import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
@@ -45,7 +46,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -67,8 +68,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@ExtendWith( {MockitoExtension.class})
+@WebMvcTest({DiscussionCommentController.class, DiscussionTopicController.class})
+@ExtendWith(MockitoExtension.class)
 @AutoConfigureMockMvc
 @EnableLinkAssemblers
 public class DiscussionTopicControllerTest {
@@ -76,6 +77,8 @@ public class DiscussionTopicControllerTest {
     private PagedResourcesAssembler<DiscussionTopicDto> paginationAssembler;
     @MockBean
     private DiscussionTopicService discussionTopicService;
+    @MockBean
+    private DiscussionCommentService discussionCommentService;
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
#### Short Description
Replaces Test Annotations (`@SpringBootTest` with `@WebMvcTest`) of the `DiscussionTopicControllerTest` and `DiscussionCommentControllerTest` to remove the database requirement. 