### PR TITLE
Fix `_embedded` relation keys in collections

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgoRelationTypeDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgoRelationTypeDto.java
@@ -6,9 +6,11 @@ import javax.validation.constraints.*;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.server.core.Relation;
 
 @Data
 @NoArgsConstructor
+@Relation(itemRelation = "algoRelationType", collectionRelation = "algoRelationTypes")
 public class AlgoRelationTypeDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
@@ -28,9 +28,9 @@ import org.planqk.atlas.core.model.Sketch;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.server.core.Relation;
 
 /**
  * Data transfer object for Algorithms ({@link org.planqk.atlas.core.model.Algorithm}).
@@ -41,6 +41,7 @@ import lombok.NoArgsConstructor;
 @JsonSubTypes( {@JsonSubTypes.Type(value = QuantumAlgorithmDto.class, name = "QUANTUM"),
         @JsonSubTypes.Type(value = ClassicAlgorithmDto.class, name = "CLASSIC"),
         @JsonSubTypes.Type(value = QuantumAlgorithmDto.class, name = "HYBRID")})
+@Relation(itemRelation = "algorithm", collectionRelation = "algorithms")
 public class AlgorithmDto {
     private UUID id;
 

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmRelationDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmRelationDto.java
@@ -26,12 +26,14 @@ import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.server.core.Relation;
 
 /**
  * Data transfer object for Algorithms ({@link org.planqk.atlas.core.model.Algorithm}).
  */
 @NoArgsConstructor
 @Data
+@Relation(itemRelation = "algorithmRelation", collectionRelation = "algorithmRelations")
 public class AlgorithmRelationDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ApplicationAreaDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ApplicationAreaDto.java
@@ -25,9 +25,11 @@ import javax.validation.constraints.NotNull;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.hateoas.server.core.Relation;
 
 @EqualsAndHashCode
 @Data
+@Relation(itemRelation = "applicationArea", collectionRelation = "applicationAreas")
 public class ApplicationAreaDto {
     private UUID id;
 

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/BackendDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/BackendDto.java
@@ -13,12 +13,14 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @ToString(callSuper = true)
 @Data
 @NoArgsConstructor
 @JsonSubTypes( {@JsonSubTypes.Type(value = QPUDto.class),
         @JsonSubTypes.Type(value = SimulatorDto.class)})
+@Relation(itemRelation = "backend", collectionRelation = "backends")
 public class BackendDto {
     private UUID id;
 

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ClassicAlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ClassicAlgorithmDto.java
@@ -7,11 +7,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Data
 @JsonTypeName("CLASSIC")
+@Relation(itemRelation = "algorithm", collectionRelation = "algorithms")
 public class ClassicAlgorithmDto extends AlgorithmDto {
     @Override
     @Schema(type = "string", allowableValues = {"CLASSIC"})

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ClassicImplementationDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ClassicImplementationDto.java
@@ -24,10 +24,12 @@ import org.planqk.atlas.core.model.ClassicAlgorithm;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Data
+@Relation(itemRelation = "implementation", collectionRelation = "implementations")
 public class ClassicImplementationDto extends ImplementationDto {
 
     private ClassicAlgorithm algorithm;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/CloudServiceDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/CloudServiceDto.java
@@ -11,10 +11,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @ToString(callSuper = true)
 @Data
 @NoArgsConstructor
+@Relation(itemRelation = "cloudService", collectionRelation = "cloudServices")
 public class CloudServiceDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ComputingResourcePropertyDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ComputingResourcePropertyDto.java
@@ -27,11 +27,13 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @Data
 @EqualsAndHashCode
 @ToString
 @NoArgsConstructor
+@Relation(itemRelation = "computingResourceProperty", collectionRelation = "computingResourceProperties")
 public class ComputingResourcePropertyDto {
     private UUID id;
     private String value;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ComputingResourcePropertyTypeDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ComputingResourcePropertyTypeDto.java
@@ -30,11 +30,13 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @Data
 @EqualsAndHashCode
 @ToString
 @NoArgsConstructor
+@Relation(itemRelation = "computingResourcePropertyType", collectionRelation = "computingResourcePropertyTypes")
 public class ComputingResourcePropertyTypeDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/DiscussionCommentDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/DiscussionCommentDto.java
@@ -28,10 +28,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.server.core.Relation;
 
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode
+@Relation(itemRelation = "discussionComment", collectionRelation = "discussionComments")
 public class DiscussionCommentDto {
     private UUID id;
     @NotNull(message = "Text must not be null!")

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/DiscussionTopicDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/DiscussionTopicDto.java
@@ -28,9 +28,11 @@ import org.planqk.atlas.core.model.Status;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.server.core.Relation;
 
 @Data
 @NoArgsConstructor
+@Relation(itemRelation = "discussionTopic", collectionRelation = "discussionTopics")
 public class DiscussionTopicDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ImplementationDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ImplementationDto.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.server.core.Relation;
 
 /**
  * Data transfer object for the model class Implementation ({@link org.planqk.atlas.core.model.Implementation}).
@@ -36,6 +37,7 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 @Data
 @NoArgsConstructor
+@Relation(itemRelation = "implementation", collectionRelation = "implementations")
 public class ImplementationDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/PatternRelationDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/PatternRelationDto.java
@@ -8,10 +8,12 @@ import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.server.core.Relation;
 
 @NoArgsConstructor
 @EqualsAndHashCode
 @Data
+@Relation(itemRelation = "patternRelation", collectionRelation = "patternRelations")
 public class PatternRelationDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/PatternRelationTypeDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/PatternRelationTypeDto.java
@@ -7,10 +7,12 @@ import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.server.core.Relation;
 
 @NoArgsConstructor
 @EqualsAndHashCode
 @Data
+@Relation(itemRelation = "patternRelationType", collectionRelation = "patternRelationTypes")
 public class PatternRelationTypeDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ProblemTypeDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/ProblemTypeDto.java
@@ -4,11 +4,13 @@ import java.util.UUID;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.hateoas.server.core.Relation;
 
 import javax.validation.constraints.*;
 
 @EqualsAndHashCode
 @Data
+@Relation(itemRelation = "problemType", collectionRelation = "problemTypes")
 public class ProblemTypeDto {
     private UUID id;
 

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/PublicationDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/PublicationDto.java
@@ -29,10 +29,12 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.URL;
+import org.springframework.hateoas.server.core.Relation;
 
 @EqualsAndHashCode
 @Data
 @NoArgsConstructor
+@Relation(itemRelation = "publication", collectionRelation = "publications")
 public class PublicationDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QPUDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QPUDto.java
@@ -3,9 +3,11 @@ package org.planqk.atlas.web.dtos;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Data
+@Relation(itemRelation = "qpu", collectionRelation = "qpus")
 public class QPUDto extends BackendDto {
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.WRITE_ONLY;
 
@@ -22,6 +23,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.WRITE_ONLY;
 @ToString(callSuper = true)
 @Data
 @JsonTypeName("QUANTUM")
+@Relation(itemRelation = "algorithm", collectionRelation = "algorithms")
 public class QuantumAlgorithmDto extends AlgorithmDto {
 
     private boolean nisqReady;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumImplementationDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumImplementationDto.java
@@ -28,10 +28,12 @@ import org.planqk.atlas.core.model.SoftwarePlatform;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Data
+@Relation(itemRelation = "implementation", collectionRelation = "implementations")
 public class QuantumImplementationDto extends ImplementationDto {
 
     private QuantumAlgorithm algorithm;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/SimulatorDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/SimulatorDto.java
@@ -3,10 +3,12 @@ package org.planqk.atlas.web.dtos;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Data
+@Relation(itemRelation = "simulator", collectionRelation = "simulators")
 public class SimulatorDto extends BackendDto {
 
     private boolean localExecution;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/SoftwarePlatformDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/SoftwarePlatformDto.java
@@ -9,10 +9,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.hateoas.server.core.Relation;
 
 @ToString(callSuper = true)
 @Data
 @NoArgsConstructor
+@Relation(itemRelation = "softwarePlatform", collectionRelation = "softwarePlatforms")
 public class SoftwarePlatformDto {
 
     private UUID id;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/TagDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/TagDto.java
@@ -21,6 +21,7 @@ package org.planqk.atlas.web.dtos;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.hateoas.server.core.Relation;
 
 import java.util.UUID;
 
@@ -28,6 +29,7 @@ import javax.validation.constraints.NotNull;
 
 @EqualsAndHashCode
 @Data
+@Relation(itemRelation = "tag", collectionRelation = "tags")
 public class TagDto {
 
     @NotNull(message = "Tag key must not be null!")

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgoRelationTypeControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgoRelationTypeControllerTest.java
@@ -160,7 +160,7 @@ public class AlgoRelationTypeControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         var providers = ObjectMapperUtils.mapResponseToList(result.getResponse().getContentAsString(),
-                "algoRelationTypeDtoes", AlgorithmRelationDto.class);
+                "algoRelationTypes", AlgorithmRelationDto.class);
         assertEquals(providers.size(), 0);
     }
 
@@ -187,7 +187,7 @@ public class AlgoRelationTypeControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         var providers = ObjectMapperUtils.mapResponseToList(result.getResponse().getContentAsString(),
-                "algoRelationTypeDtoes", AlgorithmRelationDto.class);
+                "algoRelationTypes", AlgorithmRelationDto.class);
         assertEquals(providers.size(), 2);
     }
 

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmControllerTest.java
@@ -403,7 +403,7 @@ public class AlgorithmControllerTest {
                 .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON)).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(result.getResponse().getContentAsString(),
-                "algorithmRelationDtoes", AlgorithmRelationDto.class);
+                "algorithmRelations", AlgorithmRelationDto.class);
         assertEquals(2, resultList.size());
     }
 
@@ -476,7 +476,7 @@ public class AlgorithmControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(result.getResponse().getContentAsString(),
-                "patternRelationDtoes", PatternRelationDto.class);
+                "patternRelations", PatternRelationDto.class);
         assertEquals(2, resultList.size());
     }
 
@@ -543,7 +543,7 @@ public class AlgorithmControllerTest {
 
         var resultList = ObjectMapperUtils.mapResponseToList(
                 result.getResponse().getContentAsString(),
-                "computingResourcePropertyDtoes",
+                "computingResourceProperties",
                 ComputingResourcePropertyDto.class
         );
         assertThat(resultList.size()).isEqualTo(10);

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmControllerTest.java
@@ -238,7 +238,7 @@ public class AlgorithmControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(result.getResponse().getContentAsString(),
-                "algorithmDtoes", AlgorithmDto.class);
+                "algorithms", AlgorithmDto.class);
         assertEquals(0, resultList.size());
     }
 
@@ -260,7 +260,7 @@ public class AlgorithmControllerTest {
                 .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON)).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(result.getResponse().getContentAsString(),
-                "classicAlgorithmDtoes", AlgorithmDto.class);
+                "algorithms", AlgorithmDto.class);
         assertEquals(2, resultList.size());
     }
 

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ComputingResourcePropertyTypeControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ComputingResourcePropertyTypeControllerTest.java
@@ -135,7 +135,7 @@ public class ComputingResourcePropertyTypeControllerTest {
 
         var resultList = ObjectMapperUtils.mapResponseToList(
                 result.getResponse().getContentAsString(),
-                "computingResourcePropertyTypeDtoes",
+                "computingResourcePropertyTypes",
                 ComputingResourcePropertyTypeDto.class
         );
         assertThat(resultList.size()).isEqualTo(10);

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
@@ -163,7 +163,7 @@ public class DiscussionCommentControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(result.getResponse().getContentAsString(),
-                "discussionCommentDtoes", DiscussionCommentDto.class);
+                "discussionComments", DiscussionCommentDto.class);
 
         assertEquals(resultList.size(), 1);
         assertEquals(resultList.get(0).getText(), discussionCommentDto.getText());

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionTopicControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionTopicControllerTest.java
@@ -153,7 +153,7 @@ public class DiscussionTopicControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         JSONObject rootObject = new JSONObject(result.getResponse().getContentAsString());
-        var embeddedJSONObjects = rootObject.getJSONObject("_embedded").getJSONArray("discussionTopicDtoes");
+        var embeddedJSONObjects = rootObject.getJSONObject("_embedded").getJSONArray("discussionTopics");
         var resultObject = mapper.readValue(embeddedJSONObjects.getJSONObject(0).toString(), DiscussionTopicDto.class);
 
         assertEquals(1, embeddedJSONObjects.length());

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ImplementationControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ImplementationControllerTest.java
@@ -120,7 +120,7 @@ public class ImplementationControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(mvcResult.getResponse().getContentAsString(),
-                "implementationDtoes", ImplementationDto.class);
+                "implementations", ImplementationDto.class);
 
         assertEquals(implementation.getId(), resultList.get(0).getId());
         assertEquals(1, resultList.size());
@@ -153,7 +153,7 @@ public class ImplementationControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(mvcResult.getResponse().getContentAsString(),
-                "implementationDtoes", ImplementationDto.class);
+                "implementations", ImplementationDto.class);
         assertTrue(
                 resultList.stream().map(impl -> impl.getId()).allMatch(id -> id.equals(implId1) || id.equals(implId2)));
         assertEquals(resultList.size(), implementationList.size());

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PatternRelationControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PatternRelationControllerTest.java
@@ -218,7 +218,7 @@ public class PatternRelationControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(result.getResponse().getContentAsString(),
-                "patternRelationDtoes", PatternRelationDto.class);
+                "patternRelations", PatternRelationDto.class);
 
         assertEquals(resultList.size(), 2);
         assertEquals(resultList.get(0).getDescription(), relation1Dto.getDescription());

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PatternRelationTypeControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PatternRelationTypeControllerTest.java
@@ -161,7 +161,7 @@ public class PatternRelationTypeControllerTest {
                 .andExpect(status().isOk()).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(result.getResponse().getContentAsString(),
-                "patternRelationTypeDtoes", PatternRelationTypeDto.class);
+                "patternRelationTypes", PatternRelationTypeDto.class);
 
         assertEquals(resultList.size(), 2);
         assertTrue(resultList.contains(type1Dto));

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PublicationControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/PublicationControllerTest.java
@@ -113,7 +113,7 @@ public class PublicationControllerTest {
 
         var resultList = ObjectMapperUtils.mapResponseToList(
                 result.getResponse().getContentAsString(),
-                "publicationDtoes",
+                "publications",
                 PublicationDto.class
         );
         assertThat(resultList.size()).isEqualTo(1);
@@ -129,7 +129,7 @@ public class PublicationControllerTest {
 
         var resultList = ObjectMapperUtils.mapResponseToList(
                 mvcResult.getResponse().getContentAsString(),
-                "publicationDtoes",
+                "publications",
                 PublicationDto.class
         );
         assertThat(resultList.size()).isEqualTo(0);

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/SoftwarePlatformControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/SoftwarePlatformControllerTest.java
@@ -52,7 +52,7 @@ public class SoftwarePlatformControllerTest {
     private final int page = 0;
     private final int size = 10;
     private final Pageable pageable = PageRequest.of(page, size);
-    private final String softwarePlatformDtoJSONName = "softwarePlatformDtoes";
+    private final String softwarePlatformDtoJSONName = "softwarePlatforms";
     @MockBean
     private SoftwarePlatformService softwarePlatformService;
     @Autowired


### PR DESCRIPTION
Spring HATEOAS uses the link relation names as keys in the `_embedded` resource object.
We need to use the same relation names for all algorithm types, as otherwise we end up
with several lists for the same query, for example:

```json
{
  "classicAlgorithmDtoes": [],
  "quantumAlgorithmDtoes": []
}
```

This not only breaks sorting but is also incompatible with the generated spec,
which can only consider the declared base type.
