### PR TITLE
Fix table definition for implementation <> publication relations

### DIFF
--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/model/Implementation.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/model/Implementation.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
@@ -52,6 +54,10 @@ public class Implementation extends AlgorOrImpl {
     private String dependencies;
 
     @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(name = "implementation_publication",
+            joinColumns = @JoinColumn(name = "publication_id"),
+            inverseJoinColumns = @JoinColumn(name = "implementation_id")
+    )
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     private Set<Publication> publications = new HashSet<>();


### PR DESCRIPTION
The automatically generated definition is incorrect:

```sql
CREATE TABLE public.implementation_publications
(
    implementation_id uuid NOT NULL,
    publications_id uuid NOT NULL,
    implementations_id uuid NOT NULL,
...
```
