### PR TITLE
Configure Cross Origin (CORS) globally

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/CorsConfiguration.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/CorsConfiguration.java
@@ -1,0 +1,15 @@
+package org.planqk.atlas.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfiguration implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedMethods("HEAD", "GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS");
+    }
+
+}


### PR DESCRIPTION
#### Short Description
Configure CORS using the WebMvcConfigurer

#### Proposed Changes

  * Use WebMvcConfigurer to globally allow Cross Origin Requests. To disable it, just uncomment the Configuration annotation

