### PR TITLE
Add custom argument type for data-list parameters

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/WebConfiguration.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/WebConfiguration.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web;
+
+import java.util.List;
+
+import org.planqk.atlas.web.utils.ListParametersMethodArgumentResolver;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+    @Bean
+    public ListParametersMethodArgumentResolver listParametersResolver() {
+        return new ListParametersMethodArgumentResolver();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(listParametersResolver());
+    }
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
@@ -58,6 +58,8 @@ import org.planqk.atlas.web.linkassembler.ComputingResourcePropertyAssembler;
 import org.planqk.atlas.web.linkassembler.PatternRelationAssembler;
 import org.planqk.atlas.web.linkassembler.ProblemTypeAssembler;
 import org.planqk.atlas.web.linkassembler.PublicationAssembler;
+import org.planqk.atlas.web.utils.ListParameters;
+import org.planqk.atlas.web.utils.ListParametersDoc;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 import org.planqk.atlas.web.utils.RestUtils;
 import org.planqk.atlas.web.utils.ValidationUtils;
@@ -68,7 +70,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
@@ -121,14 +122,11 @@ public class AlgorithmController {
 
     @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Retrieve all algorithms (quantum, hybrid and classic).")
     @GetMapping()
-    public HttpEntity<PagedModel<EntityModel<AlgorithmDto>>> getAlgorithms(@RequestParam(required = true, defaultValue = "0") Integer page,
-                                                                           @RequestParam(required = true, defaultValue = "50") Integer size,
-                                                                           @RequestParam(required = false, defaultValue = "desc") String sort,
-                                                                           @RequestParam(required = false) String sortBy,
-                                                                           @RequestParam(required = false) String search) {
+    @ListParametersDoc()
+    public HttpEntity<PagedModel<EntityModel<AlgorithmDto>>> getAlgorithms(ListParameters listParameters) {
         LOG.debug("Get to retrieve all algorithms received.");
-        Pageable p = RestUtils.getPageableFromRequestParams(page, size, sort, sortBy);
-        return ResponseEntity.ok(algorithmAssembler.toModel(algorithmService.findAll(p, search)));
+        return ResponseEntity.ok(algorithmAssembler.toModel(algorithmService.findAll(listParameters.getPageable(),
+                listParameters.getSearch())));
     }
 
     @Operation(responses = {@ApiResponse(responseCode = "201")}, description = "Define the basic properties of an algorithm. References to subobjects (e.g. a problemtype) can be added via subroutes (e.g. /algorithm/id/problem-types). Custom ID will be ignored.")

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
@@ -65,6 +65,7 @@ import org.planqk.atlas.web.utils.RestUtils;
 import org.planqk.atlas.web.utils.ValidationUtils;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.AllArgsConstructor;
@@ -123,7 +124,7 @@ public class AlgorithmController {
     @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Retrieve all algorithms (quantum, hybrid and classic).")
     @GetMapping()
     @ListParametersDoc()
-    public HttpEntity<PagedModel<EntityModel<AlgorithmDto>>> getAlgorithms(ListParameters listParameters) {
+    public HttpEntity<PagedModel<EntityModel<AlgorithmDto>>> getAlgorithms(@Parameter(hidden = true) ListParameters listParameters) {
         LOG.debug("Get to retrieve all algorithms received.");
         return ResponseEntity.ok(algorithmAssembler.toModel(algorithmService.findAll(listParameters.getPageable(),
                 listParameters.getSearch())));

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/RootController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/RootController.java
@@ -20,6 +20,8 @@
 package org.planqk.atlas.web.controller;
 
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.utils.ListParameters;
+import org.planqk.atlas.web.utils.RestUtils;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -54,8 +56,7 @@ public class RootController {
 
         // add links to sub-controllers
         responseEntity.add(linkTo(methodOn(RootController.class).root()).withSelfRel());
-        responseEntity.add(linkTo(methodOn(AlgorithmController.class).getAlgorithms(Constants.DEFAULT_PAGE_NUMBER,
-                Constants.DEFAULT_PAGE_SIZE, "", "", "")).withRel(Constants.ALGORITHMS));
+        responseEntity.add(linkTo(methodOn(AlgorithmController.class).getAlgorithms(ListParameters.getDefault())).withRel(Constants.ALGORITHMS));
         // This controller will be used/tested and included in the future
 //        responseEntity.add(linkTo(
 //                methodOn(TagController.class).getTags(Constants.DEFAULT_PAGE_NUMBER, Constants.DEFAULT_PAGE_SIZE))

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/ListParameters.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/ListParameters.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.utils;
+
+import org.planqk.atlas.web.Constants;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * Core parameters for a generic data list
+ */
+@RequiredArgsConstructor
+@Data
+public class ListParameters {
+    private final @NonNull Pageable pageable;
+    private final @Nullable String search;
+
+    public static ListParameters getDefault() {
+        return new ListParameters(PageRequest.of(Constants.DEFAULT_PAGE_NUMBER, Constants.DEFAULT_PAGE_SIZE), "");
+    }
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/ListParametersDoc.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/ListParametersDoc.java
@@ -18,12 +18,19 @@
  *******************************************************************************/
 package org.planqk.atlas.web.utils;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springdoc.data.rest.converters.PageableAsQueryParam;
 
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
 @PageableAsQueryParam
 @Parameter(in = ParameterIn.QUERY, description = "Filter criteria for this query ", name = "search",
         content = @Content(schema = @Schema(type = "string")))

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/ListParametersDoc.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/ListParametersDoc.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.utils;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springdoc.data.rest.converters.PageableAsQueryParam;
+
+@PageableAsQueryParam
+@Parameter(in = ParameterIn.QUERY, description = "Filter criteria for this query ", name = "search",
+        content = @Content(schema = @Schema(type = "string")))
+public @interface ListParametersDoc {
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/ListParametersMethodArgumentResolver.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/ListParametersMethodArgumentResolver.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 University of Stuttgart
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.planqk.atlas.web.utils;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolverSupport;
+import org.springframework.data.web.SortHandlerMethodArgumentResolver;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class ListParametersMethodArgumentResolver extends PageableHandlerMethodArgumentResolverSupport implements HandlerMethodArgumentResolver {
+    private final SortHandlerMethodArgumentResolver sortResolver = new SortHandlerMethodArgumentResolver();
+
+    @Override
+    public Object resolveArgument(MethodParameter methodParameter, @Nullable ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, @Nullable WebDataBinderFactory binderFactory) {
+        String page = webRequest.getParameter(getParameterNameToUse("page", methodParameter));
+        String pageSize = webRequest.getParameter(getParameterNameToUse("size", methodParameter));
+        String searchQuery = webRequest.getParameter(getParameterNameToUse("search", methodParameter));
+
+        Sort sort = sortResolver.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+        Pageable pageable = getPageable(methodParameter, page, pageSize);
+
+        if (sort.isSorted()) {
+            pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        }
+        return new ListParameters(pageable, searchQuery);
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter methodParameter) {
+        return methodParameter.getParameterType().equals(ListParameters.class);
+    }
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/RestUtils.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/RestUtils.java
@@ -45,30 +45,6 @@ public class RestUtils {
     }
 
     /**
-     * Return a (default) pageable from the provided Requestparams for an endpoint that can be used with pagination.
-     *
-     * @param page
-     * @param size
-     * @param sortType
-     * @param sortVariable
-     * @return pageable
-     */
-    public static Pageable getPageableFromRequestParams(Integer page, Integer size, String sortType, String sortVariable) {
-        if (sortVariable == null || sortVariable.isEmpty() || sortType == null || sortType.isEmpty())
-            return getPageableFromRequestParams(page, size);
-
-        // Add sorting to Pageable object if necessary information available
-        if (sortType.equals("asc")) {
-            return PageRequest.of(page, size, Sort.by(sortVariable).ascending());
-        }
-        if (sortType.equals("desc")) {
-            return PageRequest.of(page, size, Sort.by(sortVariable).descending());
-        }
-
-        return PageRequest.of(page, size);
-    }
-
-    /**
      * Returns unpaged Paginationparams
      */
     public static Pageable getAllPageable() {


### PR DESCRIPTION
To make things more robust, keep common list parameters in a dedicated class.
This way, the parameter documentation, parsing logic and so on stays the same.
Also, the amount of boilerplate code in the controllers is further reduced.