### PR TITLE
Changes duplicate operationIds to meaningful names

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
@@ -173,8 +173,9 @@ public class AlgorithmController {
         return ResponseEntity.ok(algorithmAssembler.toModel(algorithm));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "404", content = @Content, description = "Algorithm doesn't exist")},
+    @Operation(operationId = "getPublicationsByAlgorithm",
+            responses = {@ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "404", content = @Content, description = "Algorithm doesn't exist")},
             description = "Get referenced publications for an algorithm.")
     @GetMapping("/{algoId}/" + Constants.PUBLICATIONS)
     public HttpEntity<CollectionModel<EntityModel<PublicationDto>>> getPublications(@PathVariable UUID algoId) {
@@ -193,7 +194,8 @@ public class AlgorithmController {
         return ResponseEntity.ok(publicationAssembler.toModel(algorithm.getPublications()));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Get a specific referenced publication of an algorithm.")
+    @Operation(operationId = "getPublicationByAlgorithm",
+            responses = {@ApiResponse(responseCode = "200")}, description = "Get a specific referenced publication of an algorithm.")
     @GetMapping("/{algoId}/" + Constants.PUBLICATIONS + "/{publicationId}")
     public HttpEntity<EntityModel<PublicationDto>> getPublication(@PathVariable UUID algoId, @PathVariable UUID publicationId) {
         var algorithm = algorithmService.findById(algoId);
@@ -212,9 +214,10 @@ public class AlgorithmController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @Operation(responses = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "404", description = "Algorithm does not exists in the database")},
+    @Operation(operationId = "getProblemTypesByAlgorithm",
+            responses = {
+                    @ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "404", description = "Algorithm does not exists in the database")},
             description = "Get the problem types for an algorithm.")
     @GetMapping("/{algoId}/" + Constants.PROBLEM_TYPES)
     public HttpEntity<CollectionModel<EntityModel<ProblemTypeDto>>> getProblemTypes(@PathVariable UUID algoId) {
@@ -275,9 +278,10 @@ public class AlgorithmController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @Operation(responses = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "404", description = "Algorithm does not exists in the database")},
+    @Operation(operationId = "getApplicationAreasByAlgorithm",
+            responses = {
+                    @ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "404", description = "Algorithm does not exists in the database")},
             description = "Get the problem types for an algorithm.")
     @GetMapping("/{algoId}/" + Constants.APPLICATION_AREAS)
     public HttpEntity<CollectionModel<EntityModel<ApplicationAreaDto>>> getApplicationAreas(@PathVariable UUID algoId) {
@@ -343,9 +347,10 @@ public class AlgorithmController {
         return ResponseEntity.ok(patternRelationAssembler.toModel(algorithm.getRelatedPatterns()));
     }
 
-    @Operation(responses = {
-            @ApiResponse(responseCode = "201"),
-            @ApiResponse(responseCode = "404", description = "Algorithm or pattern type doesn't exist in the database")},
+    @Operation(operationId = "createPatternRelationByAlgorithm",
+            responses = {
+                    @ApiResponse(responseCode = "201"),
+                    @ApiResponse(responseCode = "404", description = "Algorithm or pattern type doesn't exist in the database")},
             description = "Add a Pattern Relation from this Algorithm to a given Pattern. Custom ID will be ignored. For pattern relation type only ID is required, other pattern relation type attributes will not change.")
     @PostMapping("/{algoId}/" + Constants.PATTERN_RELATIONS)
     public HttpEntity<EntityModel<PatternRelationDto>> createPatternRelation(@PathVariable UUID algoId,
@@ -360,10 +365,11 @@ public class AlgorithmController {
         return new ResponseEntity<>(patternRelationAssembler.toModel(saved), HttpStatus.CREATED);
     }
 
-    @Operation(responses = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", description = "PatternRelation doesn't belong to this algorithm"),
-            @ApiResponse(responseCode = "404", description = "Pattern relation or algorithm with given id doesn't exist")},
+    @Operation(operationId = "getPatternRelationByAlgorithm",
+            responses = {
+                    @ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "400", description = "PatternRelation doesn't belong to this algorithm"),
+                    @ApiResponse(responseCode = "404", description = "Pattern relation or algorithm with given id doesn't exist")},
             description = "Get a certain pattern relation for an algorithm.")
     @GetMapping("/{algoId}/" + Constants.PATTERN_RELATIONS + "/{relationId}")
     public HttpEntity<EntityModel<PatternRelationDto>> getPatternRelation(@PathVariable UUID algoId, @PathVariable UUID relationId) {
@@ -391,9 +397,10 @@ public class AlgorithmController {
         return ResponseEntity.ok(patternRelationAssembler.toModel(saved));
     }
 
-    @Operation(responses = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "404", description = "Pattern relation or algorithm with given id doesn't exist")})
+    @Operation(operationId = "deletePatternRelationByAlgorithm",
+            responses = {
+                    @ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "404", description = "Pattern relation or algorithm with given id doesn't exist")})
     @DeleteMapping("/{algoId}/" + Constants.PATTERN_RELATIONS + "/{relationId}")
     public HttpEntity<Void> deletePatternRelation(@PathVariable UUID algoId,
                                                   @PathVariable UUID relationId) {
@@ -486,11 +493,12 @@ public class AlgorithmController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @Operation(responses = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400"),
-            @ApiResponse(responseCode = "404")
-    }, description = "Retrieve the required computing resources of an algorithm")
+    @Operation(operationId = "getComputingResourcesByAlgorithm",
+            responses = {
+                    @ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "400"),
+                    @ApiResponse(responseCode = "404")
+            }, description = "Retrieve the required computing resources of an algorithm")
     @GetMapping("/{algoId}/" + Constants.COMPUTING_RESOURCES_PROPERTIES)
     public HttpEntity<PagedModel<EntityModel<ComputingResourcePropertyDto>>> getComputingResources(
             @PathVariable UUID algoId,

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationController.java
@@ -176,11 +176,12 @@ public class ImplementationController {
         return ResponseEntity.ok(computingResourcePropertyAssembler.toModel(resources));
     }
 
-    @Operation(responses = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", description = "Id of the passed computing resource type is null"),
-            @ApiResponse(responseCode = "404", description = "Computing resource type, implementation or algorithm can not be found with the given Ids")
-    }, description = "Add a computing resource (e.g. a certain number of qubits) that is requiered by an implementation. Custom ID will be ignored. For computing resource type only ID is required, other computing resource type attributes will not change")
+    @Operation(operationId = "addComputingResourceByImplementation",
+            responses = {
+                    @ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "400", description = "Id of the passed computing resource type is null"),
+                    @ApiResponse(responseCode = "404", description = "Computing resource type, implementation or algorithm can not be found with the given Ids")
+            }, description = "Add a computing resource (e.g. a certain number of qubits) that is requiered by an implementation. Custom ID will be ignored. For computing resource type only ID is required, other computing resource type attributes will not change")
     @PostMapping("/{implId}/" + Constants.COMPUTING_RESOURCES_PROPERTIES)
     public HttpEntity<EntityModel<ComputingResourcePropertyDto>> addComputingResource(
             @PathVariable UUID algoId, @PathVariable UUID implId,
@@ -194,7 +195,8 @@ public class ImplementationController {
         return ResponseEntity.ok(computingResourcePropertyAssembler.toModel(resource));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400", description = "Resource doesn't belong to this implementation"), @ApiResponse(responseCode = "404")})
+    @Operation(operationId = "getComputingResourceByImplementation",
+            responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400", description = "Resource doesn't belong to this implementation"), @ApiResponse(responseCode = "404")})
     @GetMapping("/{implId}/" + Constants.COMPUTING_RESOURCES_PROPERTIES + "/{resourceId}")
     public HttpEntity<EntityModel<ComputingResourcePropertyDto>> getComputingResource(
             @PathVariable UUID algoId, @PathVariable UUID implId, @PathVariable UUID resourceId) {
@@ -207,7 +209,8 @@ public class ImplementationController {
         return ResponseEntity.ok(computingResourcePropertyAssembler.toModel(computingResourceProperty));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400")}, description = "Update a computing resource of the implementation. Custom ID will be ignored. For computing resource type only ID is required, other computing resource type attributes will not change")
+    @Operation(operationId = "updateComputingResourceByImplementation",
+            responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400")}, description = "Update a computing resource of the implementation. Custom ID will be ignored. For computing resource type only ID is required, other computing resource type attributes will not change")
     @PutMapping("/{implId}/" + Constants.COMPUTING_RESOURCES_PROPERTIES + "/{resourceId}")
     public HttpEntity<EntityModel<ComputingResourcePropertyDto>> updateComputingResource(@PathVariable UUID algoId,
                                                                                          @PathVariable UUID implId,
@@ -227,11 +230,12 @@ public class ImplementationController {
         return ResponseEntity.ok(computingResourcePropertyAssembler.toModel(resource));
     }
 
-    @Operation(responses = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400"),
-            @ApiResponse(responseCode = "404", description = "Algorithm, Implementation or computing resource with given id doesn't exist")
-    }, description = "Delete a computing resource of the implementation.")
+    @Operation(operationId = "deleteComputingResourceByImplementation",
+            responses = {
+                    @ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "400"),
+                    @ApiResponse(responseCode = "404", description = "Algorithm, Implementation or computing resource with given id doesn't exist")
+            }, description = "Delete a computing resource of the implementation.")
     @DeleteMapping("/{implId}/" + Constants.COMPUTING_RESOURCES_PROPERTIES + "/{resourceId}")
     public HttpEntity<Void> deleteComputingResource(@PathVariable UUID algoId, @PathVariable UUID implId,
                                                     @PathVariable UUID resourceId) {
@@ -247,8 +251,9 @@ public class ImplementationController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "404", content = @Content, description = "Implementation doesn't exist")},
+    @Operation(operationId = "getPublicationsByImplementation",
+            responses = {@ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "404", content = @Content, description = "Implementation doesn't exist")},
             description = "Get referenced publications for an implementation")
     @GetMapping("/{implId}/" + Constants.PUBLICATIONS)
     public HttpEntity<CollectionModel<EntityModel<PublicationDto>>> getPublications(@PathVariable UUID algoId,
@@ -258,8 +263,9 @@ public class ImplementationController {
         return ResponseEntity.ok(publicationAssembler.toModel(publications));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404", content = @Content,
-            description = "Implementation or publication does not exist.")},
+    @Operation(operationId = "addPublicationByImplementation",
+            responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404", content = @Content,
+                    description = "Implementation or publication does not exist.")},
             description = "Add a reference to an existing publication (that was previously created via a POST on /publications/). Custom ID will be ignored. For publication only ID is required, other publication attributes will not change. If the publication doesn't exist yet, a 404 error is thrown.")
     @PostMapping("/{implId}/" + Constants.PUBLICATIONS)
     public HttpEntity<CollectionModel<EntityModel<PublicationDto>>> addPublication(@PathVariable UUID algoId,
@@ -271,7 +277,8 @@ public class ImplementationController {
         return ResponseEntity.ok(publicationAssembler.toModel(implementation.getPublications()));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Get a specific referenced publication of an implementation.")
+    @Operation(operationId = "getPublicationByImplementation",
+            responses = {@ApiResponse(responseCode = "200")}, description = "Get a specific referenced publication of an implementation.")
     @GetMapping("/{implId}/" + Constants.PUBLICATIONS + "/{publicationId}")
     public HttpEntity<EntityModel<PublicationDto>> getPublication(@PathVariable UUID algoId,
                                                                   @PathVariable UUID implId,
@@ -286,7 +293,8 @@ public class ImplementationController {
         return ResponseEntity.ok(publicationAssembler.toModel(publication));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Delete a reference to a publication of the implementation.")
+    @Operation(operationId = "deleteReferenceToPublicationByImplementation",
+            responses = {@ApiResponse(responseCode = "200")}, description = "Delete a reference to a publication of the implementation.")
     @DeleteMapping("/{implId}/" + Constants.PUBLICATIONS + "/{publicationId}")
     public HttpEntity<Void> deleteReferenceToPublication(@PathVariable UUID algoId,
                                                          @PathVariable UUID implId,
@@ -297,8 +305,9 @@ public class ImplementationController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "404", content = @Content, description = "Implementation doesn't exist")},
+    @Operation(operationId = "getSoftwarePlatformsByImplementation",
+            responses = {@ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "404", content = @Content, description = "Implementation doesn't exist")},
             description = "Get referenced software platform for an implementation")
     @GetMapping("/{implId}/" + Constants.SOFTWARE_PLATFORMS)
     public HttpEntity<CollectionModel<EntityModel<SoftwarePlatformDto>>> getSoftwarePlatforms(@PathVariable UUID algoId,
@@ -307,8 +316,9 @@ public class ImplementationController {
         return ResponseEntity.ok(softwarePlatformAssembler.toModel(implementation.getSoftwarePlatforms()));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404", content = @Content,
-            description = "Software platform or publication does not exist")},
+    @Operation(operationId = "addSoftwarePlatformByImplementation",
+            responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404", content = @Content,
+                    description = "Software platform or publication does not exist")},
             description = "Add a reference to an existing software platform (that was previously created via a POST on /software-platforms/). Custom ID will be ignored. For software platform only ID is required, other software platform attributes will not change. If the software platform doesn't exist yet, a 404 error is thrown.")
     @PostMapping("/{implId}/" + Constants.SOFTWARE_PLATFORMS)
     public HttpEntity<CollectionModel<EntityModel<SoftwarePlatformDto>>> addSoftwarePlatform(@PathVariable UUID algoId,
@@ -326,7 +336,8 @@ public class ImplementationController {
         return ResponseEntity.ok(softwarePlatformAssembler.toModel(updatedSoftwarePlatforms));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Get a specific referenced software platform of an implementation")
+    @Operation(operationId = "getSoftwarePlatformByImplementation",
+            responses = {@ApiResponse(responseCode = "200")}, description = "Get a specific referenced software platform of an implementation")
     @GetMapping("/{implId}/" + Constants.SOFTWARE_PLATFORMS + "/{platformId}")
     public HttpEntity<EntityModel<SoftwarePlatformDto>> getSoftwarePlatform(@PathVariable UUID algoId,
                                                                             @PathVariable UUID implId,

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PatternRelationController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PatternRelationController.java
@@ -61,6 +61,17 @@ public class PatternRelationController {
         return new ResponseEntity<>(handlePatternRelationUpdate(relationDto, null), HttpStatus.CREATED);
     }
 
+    @Operation(operationId = "getAllPatternRelationTypes",
+            responses = {@ApiResponse(responseCode = "200")})
+    @GetMapping()
+    public HttpEntity<PagedModel<EntityModel<PatternRelationDto>>> getPatternRelationTypes(
+            @RequestParam(required = false) Integer page, @RequestParam(required = false) Integer size) {
+        log.debug("Get to retrieve all PatternRelations received.");
+        Pageable p = RestUtils.getPageableFromRequestParams(page, size);
+        var entities = patternRelationService.findAll(p);
+        return ResponseEntity.ok(patternRelationAssembler.toModel(entities));
+    }
+
     @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400"), @ApiResponse(responseCode = "404")})
     @GetMapping("/{id}")
     public HttpEntity<EntityModel<PatternRelationDto>> getPatternRelation(@PathVariable UUID id) {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PatternRelationController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PatternRelationController.java
@@ -61,16 +61,6 @@ public class PatternRelationController {
         return new ResponseEntity<>(handlePatternRelationUpdate(relationDto, null), HttpStatus.CREATED);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200")})
-    @GetMapping()
-    public HttpEntity<PagedModel<EntityModel<PatternRelationDto>>> getPatternRelationTypes(
-            @RequestParam(required = false) Integer page, @RequestParam(required = false) Integer size) {
-        log.debug("Get to retrieve all PatternRelations received.");
-        Pageable p = RestUtils.getPageableFromRequestParams(page, size);
-        var entities = patternRelationService.findAll(p);
-        return ResponseEntity.ok(patternRelationAssembler.toModel(entities));
-    }
-
     @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400"), @ApiResponse(responseCode = "404")})
     @GetMapping("/{id}")
     public HttpEntity<EntityModel<PatternRelationDto>> getPatternRelation(@PathVariable UUID id) {
@@ -79,8 +69,9 @@ public class PatternRelationController {
         return ResponseEntity.ok(patternRelationAssembler.toModel(patternRelation));
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400"),
-            @ApiResponse(responseCode = "404")},
+    @Operation(operationId = "updatePatternRelationTypeByPattern",
+            responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400"),
+                    @ApiResponse(responseCode = "404")},
             description = "Update a reference to a pattern. Custom ID will be ignored. For pattern relation type only ID is required, other pattern relation type attributes will not change.")
     @PutMapping("/{id}")
     public HttpEntity<EntityModel<PatternRelationDto>> updatePatternRelationType(@PathVariable UUID id,


### PR DESCRIPTION
#### Short Description
Previously duplicate operationIds generated from OpenAPI received a `_[0-9]+` suffix. 
This PR fixes that by giving duplicate operationIds meaningful names.

Resolves [Issue #58](https://github.com/PlanQK/q-tal/issues/58) for the backend.
